### PR TITLE
Interactive debate: user-as-elder + elder-to-elder questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ If Gemini hits quota (common on AI Pro), set once:
 export COUNCIL_GEMINI_MODEL=gemini-2.5-flash
 ```
 
+### Participating in the debate
+
+Between rounds, the input at the bottom is re-enabled. Type a clarifying question or comment and press **Ctrl+Enter** to send it to the elders — they'll see it in the next round's prompt. Plain **Enter** just inserts a newline so you can write longer messages.
+
+Elders can also pose questions to each other by ending their reply with a block like:
+
+```
+QUESTIONS:
+@gemini Have you considered the timeline impact?
+@chatgpt What about the growth tradeoff?
+```
+
+When that happens, the question appears labelled `[To Gemini]` in the asker's pane and `[From Claude]` in the target's pane, and the target gets a "Questions directed at you" section in its next prompt.
+
 ## Keybindings during a debate
 
 | Key | Action |

--- a/council/adapters/storage/json_file.py
+++ b/council/adapters/storage/json_file.py
@@ -12,8 +12,11 @@ from council.domain.models import (
     Debate,
     ElderAnswer,
     ElderError,
+    ElderId,
+    ElderQuestion,
     Round,
     Turn,
+    UserMessage,
 )
 
 
@@ -47,6 +50,7 @@ def _serialize_debate(d: Debate) -> dict[str, Any]:
         "rounds": [_serialize_round(r) for r in d.rounds],
         "status": d.status,
         "synthesis": _serialize_answer(d.synthesis) if d.synthesis else None,
+        "user_messages": [_serialize_user_message(m) for m in d.user_messages],
     }
 
 
@@ -58,10 +62,25 @@ def _serialize_pack(p: CouncilPack) -> dict[str, Any]:
     }
 
 
+def _serialize_user_message(m: UserMessage) -> dict[str, Any]:
+    return {
+        "text": m.text,
+        "after_round": m.after_round,
+        "created_at": m.created_at.isoformat(),
+    }
+
+
 def _serialize_round(r: Round) -> dict[str, Any]:
     return {
         "number": r.number,
-        "turns": [{"elder": t.elder, "answer": _serialize_answer(t.answer)} for t in r.turns],
+        "turns": [
+            {
+                "elder": t.elder,
+                "answer": _serialize_answer(t.answer),
+                "questions": [_serialize_question(q) for q in t.questions],
+            }
+            for t in r.turns
+        ],
     }
 
 
@@ -79,8 +98,17 @@ def _serialize_answer(a: ElderAnswer) -> dict[str, Any]:
     }
 
 
+def _serialize_question(q: ElderQuestion) -> dict[str, Any]:
+    return {
+        "from_elder": q.from_elder,
+        "to_elder": q.to_elder,
+        "text": q.text,
+        "round_number": q.round_number,
+    }
+
+
 def _deserialize_debate(d: dict[str, Any]) -> Debate:
-    return Debate(
+    debate = Debate(
         id=d["id"],
         prompt=d["prompt"],
         pack=_deserialize_pack(d["pack"]),
@@ -88,6 +116,9 @@ def _deserialize_debate(d: dict[str, Any]) -> Debate:
         status=d["status"],
         synthesis=_deserialize_answer(d["synthesis"]) if d["synthesis"] else None,
     )
+    for m in d.get("user_messages", []):
+        debate.user_messages.append(_deserialize_user_message(m))
+    return debate
 
 
 def _deserialize_pack(p: dict[str, Any]) -> CouncilPack:
@@ -98,10 +129,27 @@ def _deserialize_pack(p: dict[str, Any]) -> CouncilPack:
     )
 
 
+def _deserialize_user_message(m: dict[str, Any]) -> UserMessage:
+    return UserMessage(
+        text=m["text"],
+        after_round=m["after_round"],
+        created_at=datetime.fromisoformat(m["created_at"]),
+    )
+
+
 def _deserialize_round(r: dict[str, Any]) -> Round:
     return Round(
         number=r["number"],
-        turns=[Turn(elder=t["elder"], answer=_deserialize_answer(t["answer"])) for t in r["turns"]],
+        turns=[
+            Turn(
+                elder=t["elder"],
+                answer=_deserialize_answer(t["answer"]),
+                questions=tuple(
+                    _deserialize_question(q) for q in t.get("questions", [])
+                ),
+            )
+            for t in r["turns"]
+        ],
     )
 
 
@@ -117,4 +165,13 @@ def _deserialize_answer(a: dict[str, Any]) -> ElderAnswer:
         ),
         agreed=a["agreed"],
         created_at=datetime.fromisoformat(a["created_at"]),
+    )
+
+
+def _deserialize_question(q: dict[str, Any]) -> ElderQuestion:
+    return ElderQuestion(
+        from_elder=q["from_elder"],
+        to_elder=q["to_elder"],
+        text=q["text"],
+        round_number=q["round_number"],
     )

--- a/council/adapters/storage/json_file.py
+++ b/council/adapters/storage/json_file.py
@@ -12,7 +12,6 @@ from council.domain.models import (
     Debate,
     ElderAnswer,
     ElderError,
-    ElderId,
     ElderQuestion,
     Round,
     Turn,
@@ -144,9 +143,7 @@ def _deserialize_round(r: dict[str, Any]) -> Round:
             Turn(
                 elder=t["elder"],
                 answer=_deserialize_answer(t["answer"]),
-                questions=tuple(
-                    _deserialize_question(q) for q in t.get("questions", [])
-                ),
+                questions=tuple(_deserialize_question(q) for q in t.get("questions", [])),
             )
             for t in r["turns"]
         ],

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -145,9 +145,7 @@ class CouncilApp(App):
             if isinstance(ev, TurnStarted):
                 self._view.pane(ev.elder).begin_thinking(ev.round_number)
             elif isinstance(ev, TurnCompleted):
-                self._view.pane(ev.elder).end_thinking_completed(
-                    ev.answer, questions=ev.questions
-                )
+                self._view.pane(ev.elder).end_thinking_completed(ev.answer, questions=ev.questions)
                 # Fan each outgoing question into the TARGET elder's pane.
                 for q in ev.questions:
                     self._view.pane(q.to_elder).on_incoming_question(q)

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from dataclasses import replace
 from pathlib import Path
 
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
+from textual.message import Message
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Header, Input, RichLog, Static
+from textual.widgets import Footer, Header, RichLog, Static, TextArea
 
 from council.adapters.bus.in_memory import InMemoryBus
 from council.adapters.clock.system import SystemClock
@@ -26,14 +28,29 @@ from council.domain.events import (
     TurnCompleted,
     TurnFailed,
     TurnStarted,
+    UserMessageReceived,
 )
-from council.domain.models import Debate, ElderId
+from council.domain.models import Debate, ElderId, Turn
 from council.domain.ports import (
     Clock,
     CouncilPackLoader,
     ElderPort,
     TranscriptStore,
 )
+
+
+class CouncilInput(TextArea):
+    """A TextArea that emits a Submitted message on Ctrl+Enter."""
+
+    class Submitted(Message):
+        def __init__(self, value: str) -> None:
+            super().__init__()
+            self.value = value
+
+    BINDINGS = [Binding("ctrl+enter", "submit", "Submit", show=False)]
+
+    def action_submit(self) -> None:
+        self.post_message(self.Submitted(self.text))
 
 
 class SynthesizerModal(ModalScreen[ElderId]):
@@ -58,7 +75,7 @@ class CouncilApp(App):
     CSS = """
     #notices { height: auto; max-height: 6; padding: 0 1; }
     #view { height: 1fr; }
-    #input { dock: bottom; }
+    #input { dock: bottom; min-height: 3; max-height: 8; }
     """
 
     BINDINGS = [
@@ -108,12 +125,12 @@ class CouncilApp(App):
         yield Header()
         yield RichLog(id="notices", markup=True, wrap=True, highlight=False)
         yield self._view
-        yield Input(placeholder="Ask the council…", id="input")
+        yield CouncilInput(id="input")
         yield Footer()
 
     async def on_mount(self) -> None:
         self._stream_task = self._spawn(self._consume_events())
-        self.query_one("#input", Input).focus()
+        self.query_one("#input", CouncilInput).focus()
         self._spawn(self._run_health_checks())
 
     async def on_unmount(self) -> None:
@@ -133,11 +150,17 @@ class CouncilApp(App):
                 self._view.pane(ev.elder).end_thinking_failed(ev.error)
             elif isinstance(ev, RoundCompleted):
                 self.awaiting_decision = True
+                # Re-enable input so the user can type a follow-up.
+                self.query_one("#input", CouncilInput).disabled = False
             elif isinstance(ev, SynthesisCompleted):
                 self._view.pane("synthesis").end_thinking_completed(ev.answer)
                 self._view.pane("synthesis").focus()
                 self.is_finished = True
                 self.awaiting_decision = False
+            elif isinstance(ev, UserMessageReceived):
+                # UI rendering handled by T8; placeholder no-op for now.
+                # T8 will replace this with fan-out to all elder panes.
+                pass
 
     # --- health check ----------------------------------------------------
     async def _run_health_checks(self) -> None:
@@ -164,7 +187,7 @@ class CouncilApp(App):
                 f"Install it and run its `login` command before asking a question.[/yellow]"
             )
         if len(unhealthy) == len(self._elders):
-            self.query_one("#input", Input).disabled = True
+            self.query_one("#input", CouncilInput).disabled = True
             self._write_notice(
                 "[red]No elders available. Fix the vendor CLI setup above, "
                 "then restart the app.[/red]"
@@ -175,30 +198,38 @@ class CouncilApp(App):
         self.query_one("#notices", RichLog).write(line)
 
     # --- user actions ----------------------------------------------------
-    @on(Input.Submitted, "#input")
-    async def _on_prompt_submitted(self, event: Input.Submitted) -> None:
-        prompt = event.value.strip()
-        if not prompt or self._debate is not None:
+    @on(CouncilInput.Submitted)
+    async def _on_input_submitted(self, event: CouncilInput.Submitted) -> None:
+        text = event.value.strip()
+        if not text:
             return
-        pack = self._pack_loader.load(self._pack_name)
-        self._debate = Debate(
-            id=str(uuid.uuid4()),
-            prompt=prompt,
-            pack=pack,
-            rounds=[],
-            status="in_progress",
-            synthesis=None,
-        )
-        input_widget = self.query_one("#input", Input)
-        input_widget.disabled = True
-        # Move focus onto the first elder pane.
-        self._view.pane("claude").focus()
-        self._spawn(self._service.run_round(self._debate))
+        input_widget = self.query_one("#input", CouncilInput)
+        input_widget.clear()
+        if self._debate is None:
+            # First submission — use as the initial prompt.
+            pack = self._pack_loader.load(self._pack_name)
+            self._debate = Debate(
+                id=str(uuid.uuid4()),
+                prompt=text,
+                pack=pack,
+                rounds=[],
+                status="in_progress",
+                synthesis=None,
+            )
+            input_widget.disabled = True
+            self._view.focus()
+            self._spawn(self._service.run_round(self._debate))
+        else:
+            # Between-round user message.
+            if not self.awaiting_decision:
+                return
+            self._spawn(self._service.add_user_message(self._debate, text))
 
     async def action_continue_round(self) -> None:
         if not self.awaiting_decision or self._debate is None:
             return
         self.awaiting_decision = False
+        self.query_one("#input", CouncilInput).disabled = True
         self._spawn(self._service.run_round(self._debate))
 
     async def action_abandon(self) -> None:
@@ -212,10 +243,6 @@ class CouncilApp(App):
     async def action_override(self) -> None:
         if not self.awaiting_decision or not self._debate or not self._debate.rounds:
             return
-        from dataclasses import replace
-
-        from council.domain.models import Turn
-
         r = self._debate.rounds[-1]
         r.turns = [Turn(elder=t.elder, answer=replace(t.answer, agreed=True)) for t in r.turns]
 
@@ -231,7 +258,6 @@ class CouncilApp(App):
         if choice is None:
             return
         self.awaiting_decision = False
-        self._view.show_synthesis_pane()
         self._view.pane("synthesis").begin_thinking(round_number=1)
         self._spawn(self._service.synthesize(self._debate, by=choice))
 

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -47,22 +47,10 @@ class CouncilInput(TextArea):
             super().__init__()
             self.value = value
 
-    BINDINGS = [Binding("ctrl+enter", "action_submit", "Submit", show=False)]
-
-    def __init__(self, *args, placeholder_title: str = "", **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._placeholder_title = placeholder_title
-
-    def on_mount(self) -> None:
-        if self._placeholder_title:
-            self.border_title = self._placeholder_title
+    BINDINGS = [Binding("ctrl+enter", "submit", "Submit", show=False)]
 
     def action_submit(self) -> None:
         self.post_message(self.Submitted(self.text))
-
-    def set_placeholder_title(self, title: str) -> None:
-        self._placeholder_title = title
-        self.border_title = title
 
 
 class SynthesizerModal(ModalScreen[ElderId]):
@@ -137,10 +125,7 @@ class CouncilApp(App):
         yield Header()
         yield RichLog(id="notices", markup=True, wrap=True, highlight=False)
         yield self._view
-        yield CouncilInput(
-            id="input",
-            placeholder_title="Ask the council… (Ctrl+Enter to send)",
-        )
+        yield CouncilInput(id="input")
         yield Footer()
 
     async def on_mount(self) -> None:
@@ -169,11 +154,7 @@ class CouncilApp(App):
             elif isinstance(ev, RoundCompleted):
                 self.awaiting_decision = True
                 # Re-enable input so the user can type a follow-up.
-                input_widget = self.query_one("#input", CouncilInput)
-                input_widget.disabled = False
-                input_widget.set_placeholder_title(
-                    "Anything to add? (Ctrl+Enter to send, or press a shortcut)"
-                )
+                self.query_one("#input", CouncilInput).disabled = False
             elif isinstance(ev, SynthesisCompleted):
                 self._view.pane("synthesis").end_thinking_completed(ev.answer)
                 self._view.pane("synthesis").focus()

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -47,10 +47,22 @@ class CouncilInput(TextArea):
             super().__init__()
             self.value = value
 
-    BINDINGS = [Binding("ctrl+enter", "submit", "Submit", show=False)]
+    BINDINGS = [Binding("ctrl+enter", "action_submit", "Submit", show=False)]
+
+    def __init__(self, *args, placeholder_title: str = "", **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._placeholder_title = placeholder_title
+
+    def on_mount(self) -> None:
+        if self._placeholder_title:
+            self.border_title = self._placeholder_title
 
     def action_submit(self) -> None:
         self.post_message(self.Submitted(self.text))
+
+    def set_placeholder_title(self, title: str) -> None:
+        self._placeholder_title = title
+        self.border_title = title
 
 
 class SynthesizerModal(ModalScreen[ElderId]):
@@ -125,7 +137,10 @@ class CouncilApp(App):
         yield Header()
         yield RichLog(id="notices", markup=True, wrap=True, highlight=False)
         yield self._view
-        yield CouncilInput(id="input")
+        yield CouncilInput(
+            id="input",
+            placeholder_title="Ask the council… (Ctrl+Enter to send)",
+        )
         yield Footer()
 
     async def on_mount(self) -> None:
@@ -154,7 +169,11 @@ class CouncilApp(App):
             elif isinstance(ev, RoundCompleted):
                 self.awaiting_decision = True
                 # Re-enable input so the user can type a follow-up.
-                self.query_one("#input", CouncilInput).disabled = False
+                input_widget = self.query_one("#input", CouncilInput)
+                input_widget.disabled = False
+                input_widget.set_placeholder_title(
+                    "Anything to add? (Ctrl+Enter to send, or press a shortcut)"
+                )
             elif isinstance(ev, SynthesisCompleted):
                 self._view.pane("synthesis").end_thinking_completed(ev.answer)
                 self._view.pane("synthesis").focus()

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -145,7 +145,12 @@ class CouncilApp(App):
             if isinstance(ev, TurnStarted):
                 self._view.pane(ev.elder).begin_thinking(ev.round_number)
             elif isinstance(ev, TurnCompleted):
-                self._view.pane(ev.elder).end_thinking_completed(ev.answer)
+                self._view.pane(ev.elder).end_thinking_completed(
+                    ev.answer, questions=ev.questions
+                )
+                # Fan each outgoing question into the TARGET elder's pane.
+                for q in ev.questions:
+                    self._view.pane(q.to_elder).on_incoming_question(q)
             elif isinstance(ev, TurnFailed):
                 self._view.pane(ev.elder).end_thinking_failed(ev.error)
             elif isinstance(ev, RoundCompleted):
@@ -158,9 +163,9 @@ class CouncilApp(App):
                 self.is_finished = True
                 self.awaiting_decision = False
             elif isinstance(ev, UserMessageReceived):
-                # UI rendering handled by T8; placeholder no-op for now.
-                # T8 will replace this with fan-out to all elder panes.
-                pass
+                # Dispatch to all three elder panes for inline rendering.
+                for pane_key in ("claude", "gemini", "chatgpt"):
+                    self._view.pane(pane_key).on_user_message(ev.message)
 
     # --- health check ----------------------------------------------------
     async def _run_health_checks(self) -> None:

--- a/council/app/tui/elder_pane.py
+++ b/council/app/tui/elder_pane.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from council.domain.models import ElderAnswer, ElderError, ElderId, ElderQuestion, UserMessage
+from council.domain.models import ElderAnswer, ElderError, ElderQuestion, UserMessage
 from council.domain.ports import Clock
 from council.app.tui.verbs import VerbChooser
 
@@ -230,7 +230,7 @@ class ElderPaneWidget(ElderPane, Widget):
         self._append_completed(answer)
         # Render the asker's own outgoing questions below the answer.
         for q in questions:
-            self._append_to_line(f'[dim][To {_display(q.to_elder)}][/] {q.text}')
+            self._append_to_line(f"[dim][To {_display(q.to_elder)}][/] {q.text}")
         self.label_text = self.current_label()
 
     def end_thinking_failed(self, error: ElderError) -> None:
@@ -316,14 +316,10 @@ class ElderPaneWidget(ElderPane, Widget):
         self._last_round_rendered = self._current_round
 
     def on_user_message(self, message: UserMessage) -> None:
-        self._append_to_line(
-            f'[dim][You after round {message.after_round}][/] {message.text}'
-        )
+        self._append_to_line(f"[dim][You after round {message.after_round}][/] {message.text}")
 
     def on_incoming_question(self, question: ElderQuestion) -> None:
-        self._append_to_line(
-            f'[dim][From {_display(question.from_elder)}][/] {question.text}'
-        )
+        self._append_to_line(f"[dim][From {_display(question.from_elder)}][/] {question.text}")
 
     def _append_to_line(self, line: str) -> None:
         self._history_buffer.append(line)

--- a/council/app/tui/elder_pane.py
+++ b/council/app/tui/elder_pane.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from council.domain.models import ElderAnswer, ElderError
+from council.domain.models import ElderAnswer, ElderError, ElderId, ElderQuestion, UserMessage
 from council.domain.ports import Clock
 from council.app.tui.verbs import VerbChooser
 
@@ -141,6 +141,16 @@ from council.domain.events import TurnCompleted, TurnFailed  # noqa: E402
 
 _SYNTHESIS_PLACEHOLDER = "[dim]Synthesis runs after you press [bold]s[/] and pick an elder.[/dim]"
 
+_DISPLAY_NAMES: dict[str, str] = {
+    "claude": "Claude",
+    "gemini": "Gemini",
+    "chatgpt": "ChatGPT",
+}
+
+
+def _display(elder: str) -> str:
+    return _DISPLAY_NAMES.get(elder, elder)
+
 
 class ElderPaneWidget(ElderPane, Widget):
     """Textual widget wrapping the label state machine with a history log."""
@@ -209,11 +219,18 @@ class ElderPaneWidget(ElderPane, Widget):
         self._cancel_ticker()
         self._ticker_task = asyncio.create_task(self._tick_loop())
 
-    def end_thinking_completed(self, answer: ElderAnswer) -> None:
+    def end_thinking_completed(
+        self,
+        answer: ElderAnswer,
+        questions: tuple[ElderQuestion, ...] = (),
+    ) -> None:
         self._cancel_ticker()
         super().end_thinking_completed(answer)
         self._clear_thinking_line()
         self._append_completed(answer)
+        # Render the asker's own outgoing questions below the answer.
+        for q in questions:
+            self._append_to_line(f'[dim][To {_display(q.to_elder)}][/] {q.text}')
         self.label_text = self.current_label()
 
     def end_thinking_failed(self, error: ElderError) -> None:
@@ -297,6 +314,20 @@ class ElderPaneWidget(ElderPane, Widget):
         log.write(line)
         self._history_buffer.append(line)
         self._last_round_rendered = self._current_round
+
+    def on_user_message(self, message: UserMessage) -> None:
+        self._append_to_line(
+            f'[dim][You after round {message.after_round}][/] {message.text}'
+        )
+
+    def on_incoming_question(self, question: ElderQuestion) -> None:
+        self._append_to_line(
+            f'[dim][From {_display(question.from_elder)}][/] {question.text}'
+        )
+
+    def _append_to_line(self, line: str) -> None:
+        self._history_buffer.append(line)
+        self.query_one("#pane-history", RichLog).write(line)
 
     # --- test helper -----------------------------------------------------
     def history_text(self) -> str:

--- a/council/domain/debate_service.py
+++ b/council/domain/debate_service.py
@@ -10,6 +10,7 @@ from council.domain.events import (
     TurnCompleted,
     TurnFailed,
     TurnStarted,
+    UserMessageReceived,
 )
 from council.domain.models import (
     Debate,
@@ -18,9 +19,11 @@ from council.domain.models import (
     ElderId,
     Round,
     Turn,
+    UserMessage,
 )
 from council.domain.ports import Clock, ElderPort, EventBus, TranscriptStore
 from council.domain.prompting import PromptBuilder
+from council.domain.questions import QuestionParser
 
 
 @dataclass
@@ -31,6 +34,7 @@ class DebateService:
     bus: EventBus
     prompt_builder: PromptBuilder = PromptBuilder()
     convergence: ConvergencePolicy = ConvergencePolicy()
+    question_parser: QuestionParser = QuestionParser()
 
     async def run_round(self, debate: Debate) -> Round:
         round_num = len(debate.rounds) + 1
@@ -59,17 +63,25 @@ class DebateService:
                 return Turn(elder=elder_id, answer=ans)
 
             cleaned, agreed = self.convergence.parse(raw)
+            cleaned_no_qs, questions = self.question_parser.parse(
+                cleaned, from_elder=elder_id, round_number=round_num
+            )
             ans = ElderAnswer(
                 elder=elder_id,
-                text=cleaned,
+                text=cleaned_no_qs,
                 error=None,
                 agreed=agreed,
                 created_at=self.clock.now(),
             )
             await self.bus.publish(
-                TurnCompleted(elder=elder_id, round_number=round_num, answer=ans)
+                TurnCompleted(
+                    elder=elder_id,
+                    round_number=round_num,
+                    answer=ans,
+                    questions=questions,
+                )
             )
-            return Turn(elder=elder_id, answer=ans)
+            return Turn(elder=elder_id, answer=ans, questions=questions)
 
         turns = await asyncio.gather(*(_ask(eid) for eid in self.elders.keys()))
         r = Round(number=round_num, turns=list(turns))
@@ -103,6 +115,17 @@ class DebateService:
         self.store.save(debate)
         await self.bus.publish(SynthesisCompleted(answer=ans))
         return ans
+
+    async def add_user_message(self, debate: Debate, text: str) -> UserMessage:
+        msg = UserMessage(
+            text=text.strip(),
+            after_round=len(debate.rounds),
+            created_at=self.clock.now(),
+        )
+        debate.user_messages.append(msg)
+        self.store.save(debate)
+        await self.bus.publish(UserMessageReceived(message=msg))
+        return msg
 
     def _error_answer(self, elder_id: ElderId, err: ElderError) -> ElderAnswer:
         return ElderAnswer(

--- a/council/domain/events.py
+++ b/council/domain/events.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
-from council.domain.models import ElderAnswer, ElderError, ElderId, ElderQuestion, Round, UserMessage
+from council.domain.models import (
+    ElderAnswer,
+    ElderError,
+    ElderId,
+    ElderQuestion,
+    Round,
+    UserMessage,
+)
 
 
 @dataclass(frozen=True)

--- a/council/domain/events.py
+++ b/council/domain/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
-from council.domain.models import ElderAnswer, ElderError, ElderId, Round, UserMessage
+from council.domain.models import ElderAnswer, ElderError, ElderId, ElderQuestion, Round, UserMessage
 
 
 @dataclass(frozen=True)
@@ -17,6 +17,7 @@ class TurnCompleted:
     elder: ElderId
     round_number: int
     answer: ElderAnswer
+    questions: tuple[ElderQuestion, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/council/domain/events.py
+++ b/council/domain/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Union
 
-from council.domain.models import ElderAnswer, ElderError, ElderId, Round
+from council.domain.models import ElderAnswer, ElderError, ElderId, Round, UserMessage
 
 
 @dataclass(frozen=True)
@@ -41,6 +41,11 @@ class DebateAbandoned:
     pass
 
 
+@dataclass(frozen=True)
+class UserMessageReceived:
+    message: UserMessage
+
+
 DebateEvent = Union[
     TurnStarted,
     TurnCompleted,
@@ -48,4 +53,5 @@ DebateEvent = Union[
     RoundCompleted,
     SynthesisCompleted,
     DebateAbandoned,
+    UserMessageReceived,
 ]

--- a/council/domain/models.py
+++ b/council/domain/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal
 
@@ -33,9 +33,25 @@ class ElderAnswer:
 
 
 @dataclass(frozen=True)
+class UserMessage:
+    text: str
+    after_round: int
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ElderQuestion:
+    from_elder: ElderId
+    to_elder: ElderId
+    text: str
+    round_number: int
+
+
+@dataclass(frozen=True)
 class Turn:
     elder: ElderId
     answer: ElderAnswer
+    questions: tuple[ElderQuestion, ...] = ()
 
 
 @dataclass
@@ -66,3 +82,4 @@ class Debate:
     rounds: list[Round]
     status: DebateStatus
     synthesis: ElderAnswer | None
+    user_messages: list[UserMessage] = field(default_factory=list)

--- a/council/domain/prompting.py
+++ b/council/domain/prompting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from council.domain.models import Debate, ElderId, Round
+from council.domain.models import Debate, ElderId
 
 _CONVERGED_INSTRUCTION = (
     "End your reply with exactly one of:\n"
@@ -61,8 +61,7 @@ class PromptBuilder:
             parts.append(other_qs)
 
         parts.append(
-            "You may revise your answer if their arguments change your view, "
-            "or stand by it."
+            "You may revise your answer if their arguments change your view, or stand by it."
         )
         parts.append(_QUESTIONS_INSTRUCTION)
         parts.append(_CONVERGED_INSTRUCTION)
@@ -93,18 +92,14 @@ class PromptBuilder:
             lines.append(debate.pack.shared_context.strip())
         return "\n\n".join(lines)
 
-    def _own_previous_answer(
-        self, debate: Debate, elder: ElderId, round_num: int
-    ) -> str | None:
+    def _own_previous_answer(self, debate: Debate, elder: ElderId, round_num: int) -> str | None:
         prior = debate.rounds[round_num - 2]
         for t in prior.turns:
             if t.elder == elder and t.answer.text:
                 return t.answer.text
         return None
 
-    def _other_advisors_section(
-        self, debate: Debate, elder: ElderId, round_num: int
-    ) -> str:
+    def _other_advisors_section(self, debate: Debate, elder: ElderId, round_num: int) -> str:
         prior = debate.rounds[round_num - 2]
         lines = ["Other advisors said:"]
         for t in prior.turns:
@@ -125,26 +120,18 @@ class PromptBuilder:
             lines.append(f'After round {m.after_round}: "{m.text}"')
         return "\n".join(lines)
 
-    def _directed_questions_section(
-        self, debate: Debate, elder: ElderId, round_num: int
-    ) -> str:
+    def _directed_questions_section(self, debate: Debate, elder: ElderId, round_num: int) -> str:
         prior = debate.rounds[round_num - 2]
         directed: list[str] = []
         for t in prior.turns:
             for q in t.questions:
                 if q.to_elder == elder:
-                    directed.append(
-                        f'- From {_ELDER_LABEL[q.from_elder]}: "{q.text}"'
-                    )
+                    directed.append(f'- From {_ELDER_LABEL[q.from_elder]}: "{q.text}"')
         if not directed:
             return ""
-        return "Questions directed at you from the previous round:\n" + "\n".join(
-            directed
-        )
+        return "Questions directed at you from the previous round:\n" + "\n".join(directed)
 
-    def _other_questions_section(
-        self, debate: Debate, elder: ElderId, round_num: int
-    ) -> str:
+    def _other_questions_section(self, debate: Debate, elder: ElderId, round_num: int) -> str:
         prior = debate.rounds[round_num - 2]
         others: list[str] = []
         for t in prior.turns:
@@ -152,8 +139,7 @@ class PromptBuilder:
                 if q.to_elder == elder:
                     continue
                 others.append(
-                    f'- [{_ELDER_LABEL[q.from_elder]} to '
-                    f'{_ELDER_LABEL[q.to_elder]}]: "{q.text}"'
+                    f'- [{_ELDER_LABEL[q.from_elder]} to {_ELDER_LABEL[q.to_elder]}]: "{q.text}"'
                 )
         if not others:
             return ""

--- a/council/domain/prompting.py
+++ b/council/domain/prompting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from council.domain.models import Debate, ElderId
+from council.domain.models import Debate, ElderId, Round
 
 _CONVERGED_INSTRUCTION = (
     "End your reply with exactly one of:\n"
@@ -8,6 +8,14 @@ _CONVERGED_INSTRUCTION = (
     "CONVERGED: no\n\n"
     "(Use CONVERGED: yes only if you would not change your answer after seeing "
     "what other advisors say.)"
+)
+
+_QUESTIONS_INSTRUCTION = (
+    "If you have questions for another advisor, optionally include them "
+    "BEFORE the CONVERGED line, as a block like this:\n\n"
+    "QUESTIONS:\n"
+    "@gemini your question here\n"
+    "@chatgpt another question\n"
 )
 
 _ELDER_LABEL: dict[ElderId, str] = {
@@ -27,6 +35,7 @@ class PromptBuilder:
 
         if round_num == 1:
             parts.append("Answer the question.")
+            parts.append(_QUESTIONS_INSTRUCTION)
             parts.append(_CONVERGED_INSTRUCTION)
             return "\n\n".join(parts)
 
@@ -39,9 +48,23 @@ class PromptBuilder:
         if others:
             parts.append(others)
 
+        user_section = self._user_messages_section(debate)
+        if user_section:
+            parts.append(user_section)
+
+        directed = self._directed_questions_section(debate, elder, round_num)
+        if directed:
+            parts.append(directed)
+
+        other_qs = self._other_questions_section(debate, elder, round_num)
+        if other_qs:
+            parts.append(other_qs)
+
         parts.append(
-            "You may revise your answer if their arguments change your view, or stand by it."
+            "You may revise your answer if their arguments change your view, "
+            "or stand by it."
         )
+        parts.append(_QUESTIONS_INSTRUCTION)
         parts.append(_CONVERGED_INSTRUCTION)
         return "\n\n".join(parts)
 
@@ -54,7 +77,7 @@ class PromptBuilder:
         parts.append(self._all_rounds_section(debate))
         parts.append(
             "You have seen every advisor's contribution across every round. "
-            "Produce the final synthesized answer that best represents the "
+            "Produce the final synthesised answer that best represents the "
             "consensus (or, where no consensus exists, your best judgment "
             "informed by the debate). Do not append a convergence tag."
         )
@@ -70,14 +93,18 @@ class PromptBuilder:
             lines.append(debate.pack.shared_context.strip())
         return "\n\n".join(lines)
 
-    def _own_previous_answer(self, debate: Debate, elder: ElderId, round_num: int) -> str | None:
+    def _own_previous_answer(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str | None:
         prior = debate.rounds[round_num - 2]
         for t in prior.turns:
             if t.elder == elder and t.answer.text:
                 return t.answer.text
         return None
 
-    def _other_advisors_section(self, debate: Debate, elder: ElderId, round_num: int) -> str:
+    def _other_advisors_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
         prior = debate.rounds[round_num - 2]
         lines = ["Other advisors said:"]
         for t in prior.turns:
@@ -89,6 +116,48 @@ class PromptBuilder:
         if len(lines) == 1:
             return ""
         return "\n".join(lines)
+
+    def _user_messages_section(self, debate: Debate) -> str:
+        if not debate.user_messages:
+            return ""
+        lines = ["You (the asker) said:"]
+        for m in debate.user_messages:
+            lines.append(f'After round {m.after_round}: "{m.text}"')
+        return "\n".join(lines)
+
+    def _directed_questions_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
+        prior = debate.rounds[round_num - 2]
+        directed: list[str] = []
+        for t in prior.turns:
+            for q in t.questions:
+                if q.to_elder == elder:
+                    directed.append(
+                        f'- From {_ELDER_LABEL[q.from_elder]}: "{q.text}"'
+                    )
+        if not directed:
+            return ""
+        return "Questions directed at you from the previous round:\n" + "\n".join(
+            directed
+        )
+
+    def _other_questions_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
+        prior = debate.rounds[round_num - 2]
+        others: list[str] = []
+        for t in prior.turns:
+            for q in t.questions:
+                if q.to_elder == elder:
+                    continue
+                others.append(
+                    f'- [{_ELDER_LABEL[q.from_elder]} to '
+                    f'{_ELDER_LABEL[q.to_elder]}]: "{q.text}"'
+                )
+        if not others:
+            return ""
+        return "Other questions raised between advisors:\n" + "\n".join(others)
 
     def _all_rounds_section(self, debate: Debate) -> str:
         chunks: list[str] = []

--- a/council/domain/questions.py
+++ b/council/domain/questions.py
@@ -17,6 +17,7 @@ Rules:
 - If the block isn't at the tail (non-blank content after the last
   `@elder` line of the block), treat as not a block and return unchanged.
 """
+
 from __future__ import annotations
 
 import re
@@ -54,9 +55,7 @@ class QuestionParser:
 
         # Check if there's any non-blank body content before the header.
         # If not, the block is not "at tail" of the body.
-        has_body_before = any(
-            lines[i].strip() for i in range(header_idx)
-        )
+        has_body_before = any(lines[i].strip() for i in range(header_idx))
         if not has_body_before:
             return raw, ()
 

--- a/council/domain/questions.py
+++ b/council/domain/questions.py
@@ -1,0 +1,109 @@
+"""Parse a trailing `QUESTIONS: @elder text` block from an elder's reply.
+
+Runs after ConvergencePolicy in DebateService so the CONVERGED tag is
+already removed. Returns (cleaned_text, questions) where questions is a
+tuple of ElderQuestion and cleaned_text has the entire QUESTIONS block
+stripped. If no valid block is found, returns (raw, ()).
+
+Rules:
+- Looks for the last `QUESTIONS:` header followed by at least one valid
+  `@elder text` line, where the block extends to end-of-input or a blank
+  line.
+- Only @claude / @gemini / @chatgpt are valid; unknown @-prefixed lines
+  inside the block are tolerated as noise but not emitted.
+- An elder's own self-directed question (@claude from claude) is dropped.
+- If the block has no valid `@elder` lines, the whole input is returned
+  unchanged with `()` — the header was a false positive.
+- If the block isn't at the tail (non-blank content after the last
+  `@elder` line of the block), treat as not a block and return unchanged.
+"""
+from __future__ import annotations
+
+import re
+from typing import get_args
+
+from council.domain.models import ElderId, ElderQuestion
+
+_HEADER_RE = re.compile(r"^\s*QUESTIONS\s*:\s*$", re.IGNORECASE)
+_TAG_LINE_RE = re.compile(
+    r"^\s*@(claude|gemini|chatgpt)\s+(.+?)\s*$",
+    re.IGNORECASE,
+)
+_VALID_ELDERS: tuple[str, ...] = get_args(ElderId)
+
+
+class QuestionParser:
+    def parse(
+        self,
+        raw: str,
+        *,
+        from_elder: ElderId,
+        round_number: int,
+    ) -> tuple[str, tuple[ElderQuestion, ...]]:
+        if not raw:
+            return "", ()
+        lines = raw.splitlines()
+        # Find the last QUESTIONS: header.
+        header_idx: int | None = None
+        for i in range(len(lines) - 1, -1, -1):
+            if _HEADER_RE.match(lines[i]):
+                header_idx = i
+                break
+        if header_idx is None:
+            return raw, ()
+
+        # Check if there's any non-blank body content before the header.
+        # If not, the block is not "at tail" of the body.
+        has_body_before = any(
+            lines[i].strip() for i in range(header_idx)
+        )
+        if not has_body_before:
+            return raw, ()
+
+        # Read @elder lines after the header, up to blank line or EOF.
+        last_question_idx = -1
+        questions: list[ElderQuestion] = []
+        for j in range(header_idx + 1, len(lines)):
+            line = lines[j]
+            if not line.strip():
+                # Blank line terminates the block.
+                break
+            m = _TAG_LINE_RE.match(line)
+            if not m:
+                # Non-matching, non-blank line inside block — tolerate as
+                # noise, but keep reading.
+                continue
+            target = m.group(1).lower()
+            text = m.group(2).strip()
+            if target == from_elder:
+                continue  # drop self-directed
+            if target not in _VALID_ELDERS:
+                continue  # defensive
+            last_question_idx = j
+            questions.append(
+                ElderQuestion(
+                    from_elder=from_elder,
+                    to_elder=target,  # type: ignore[arg-type]
+                    text=text,
+                    round_number=round_number,
+                )
+            )
+
+        if not questions:
+            return raw, ()
+
+        # Find where the block ends (at the first blank line or EOF).
+        block_end_idx = last_question_idx + 1
+        if block_end_idx < len(lines) and not lines[block_end_idx].strip():
+            # Next line after last question is blank; block ends there.
+            block_end_idx += 1
+        else:
+            # No blank line found; block extends to EOF. Check for any
+            # non-blank content after the last question (no blank line sep).
+            for line in lines[block_end_idx:]:
+                if line.strip():
+                    return raw, ()
+
+        # Reconstruct: body before header + body after block.
+        cleaned = "\n".join(lines[:header_idx] + lines[block_end_idx:]).rstrip()
+        return cleaned, tuple(questions)

--- a/docs/superpowers/plans/2026-04-19-interactive-debate.md
+++ b/docs/superpowers/plans/2026-04-19-interactive-debate.md
@@ -1,0 +1,1993 @@
+# Interactive Debate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user take part in the debate (type messages between rounds that feed into subsequent elder prompts) and let elders pose structured questions to each other (via `QUESTIONS: @elder …` tail blocks), with all messages rendered inline in each elder's pane.
+
+**Architecture:** Additive domain changes (two new value objects, one new event, one new parser, extended PromptBuilder + DebateService, extended JsonFileStore) plus primary-adapter TUI updates (Input → TextArea, event routing, pane rendering). Ports and vendor adapters unchanged.
+
+**Tech Stack:** Python 3.12+, Textual (TextArea widget), pytest + pytest-asyncio, ruff.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-19-interactive-debate-design.md`
+
+---
+
+## Task 1: Domain value objects — UserMessage, ElderQuestion, Debate/Turn extensions
+
+**Files:**
+- Modify: `council/domain/models.py`
+- Test: `tests/unit/test_models.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_models.py`:
+
+```python
+from council.domain.models import UserMessage, ElderQuestion
+
+
+class TestUserMessage:
+    def test_construct_with_expected_fields(self):
+        m = UserMessage(
+            text="clarify scope please",
+            after_round=1,
+            created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
+        assert m.text == "clarify scope please"
+        assert m.after_round == 1
+
+    def test_is_frozen(self):
+        m = UserMessage(
+            text="x",
+            after_round=0,
+            created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
+        with pytest.raises(Exception):
+            m.text = "y"  # type: ignore[misc]
+
+
+class TestElderQuestion:
+    def test_construct_with_expected_fields(self):
+        q = ElderQuestion(
+            from_elder="claude",
+            to_elder="gemini",
+            text="Have you considered X?",
+            round_number=1,
+        )
+        assert q.from_elder == "claude"
+        assert q.to_elder == "gemini"
+
+    def test_is_frozen(self):
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini", text="x", round_number=1
+        )
+        with pytest.raises(Exception):
+            q.text = "y"  # type: ignore[misc]
+
+
+class TestDebateUserMessages:
+    def test_fresh_debate_has_empty_user_messages(self):
+        pack = CouncilPack(name="bare", shared_context=None, personas={})
+        d = Debate(
+            id="d1",
+            prompt="?",
+            pack=pack,
+            rounds=[],
+            status="in_progress",
+            synthesis=None,
+        )
+        assert d.user_messages == []
+
+
+class TestTurnQuestions:
+    def test_fresh_turn_has_empty_questions(self):
+        t = Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude",
+                text="hi",
+                error=None,
+                agreed=True,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            ),
+        )
+        assert t.questions == ()
+
+    def test_turn_with_questions(self):
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini", text="?", round_number=1
+        )
+        t = Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude",
+                text="hi",
+                error=None,
+                agreed=True,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            ),
+            questions=(q,),
+        )
+        assert len(t.questions) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_models.py -v -k "UserMessage or ElderQuestion or UserMessages or TurnQuestions"`
+Expected: FAIL — `ImportError` on `UserMessage` and `ElderQuestion`.
+
+- [ ] **Step 3: Extend `council/domain/models.py`**
+
+Add below `ElderAnswer`:
+
+```python
+@dataclass(frozen=True)
+class UserMessage:
+    text: str
+    after_round: int
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ElderQuestion:
+    from_elder: ElderId
+    to_elder: ElderId
+    text: str
+    round_number: int
+```
+
+Replace the existing `Turn` with:
+
+```python
+@dataclass(frozen=True)
+class Turn:
+    elder: ElderId
+    answer: ElderAnswer
+    questions: tuple[ElderQuestion, ...] = ()
+```
+
+Replace the existing `Debate` with (adding the `field` import at the top of the file if missing):
+
+```python
+@dataclass
+class Debate:
+    id: str
+    prompt: str
+    pack: CouncilPack
+    rounds: list[Round]
+    status: DebateStatus
+    synthesis: ElderAnswer | None
+    user_messages: list[UserMessage] = field(default_factory=list)
+```
+
+Add `from dataclasses import dataclass, field` to the imports at the top if only `dataclass` was imported.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_models.py -v`
+Expected: all tests pass (previous + 6 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add council/domain/models.py tests/unit/test_models.py
+git commit -m "feat(domain): add UserMessage and ElderQuestion; extend Debate and Turn"
+```
+
+---
+
+## Task 2: UserMessageReceived domain event
+
+**Files:**
+- Modify: `council/domain/events.py`
+- Test: `tests/unit/test_events.py` (extend)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/unit/test_events.py`:
+
+```python
+from council.domain.events import UserMessageReceived
+from council.domain.models import UserMessage
+
+
+def test_user_message_received_carries_message():
+    m = UserMessage(
+        text="clarify please",
+        after_round=1,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    e = UserMessageReceived(message=m)
+    assert e.message is m
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_events.py -v -k "user_message_received"`
+Expected: FAIL — ImportError.
+
+- [ ] **Step 3: Extend `council/domain/events.py`**
+
+Add:
+
+```python
+from council.domain.models import UserMessage
+```
+to the imports (alongside existing ones).
+
+Add this dataclass above the `DebateEvent` union:
+
+```python
+@dataclass(frozen=True)
+class UserMessageReceived:
+    message: UserMessage
+```
+
+Update the union:
+
+```python
+DebateEvent = Union[
+    TurnStarted,
+    TurnCompleted,
+    TurnFailed,
+    RoundCompleted,
+    SynthesisCompleted,
+    DebateAbandoned,
+    UserMessageReceived,
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_events.py -v`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add council/domain/events.py tests/unit/test_events.py
+git commit -m "feat(domain): add UserMessageReceived event"
+```
+
+---
+
+## Task 3: QuestionParser
+
+**Files:**
+- Create: `council/domain/questions.py`
+- Test: `tests/unit/test_question_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_question_parser.py`:
+
+```python
+import pytest
+
+from council.domain.questions import QuestionParser
+
+
+@pytest.fixture
+def parser():
+    return QuestionParser()
+
+
+class TestNoBlock:
+    def test_no_questions_header_returns_raw_and_empty(self, parser):
+        raw = "Here is my answer with no questions."
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert cleaned == raw
+        assert qs == ()
+
+    def test_empty_input(self, parser):
+        cleaned, qs = parser.parse("", from_elder="claude", round_number=1)
+        assert cleaned == ""
+        assert qs == ()
+
+
+class TestValidBlock:
+    def test_single_question_extracted(self, parser):
+        raw = (
+            "My answer text.\n"
+            "\n"
+            "QUESTIONS:\n"
+            "@gemini Have you considered timeline?"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert "QUESTIONS:" not in cleaned
+        assert "@gemini" not in cleaned
+        assert cleaned.strip() == "My answer text."
+        assert len(qs) == 1
+        assert qs[0].from_elder == "claude"
+        assert qs[0].to_elder == "gemini"
+        assert qs[0].text == "Have you considered timeline?"
+        assert qs[0].round_number == 1
+
+    def test_multiple_questions_extracted(self, parser):
+        raw = (
+            "Answer.\n"
+            "QUESTIONS:\n"
+            "@gemini Timeline?\n"
+            "@chatgpt Growth?"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=2)
+        assert cleaned.strip() == "Answer."
+        assert len(qs) == 2
+        assert {q.to_elder for q in qs} == {"gemini", "chatgpt"}
+
+    def test_case_insensitive_header_and_elder(self, parser):
+        raw = "Answer.\nquestions:\n@GEMINI Timeline?"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+
+class TestMalformedOrUnknown:
+    def test_unknown_elder_ignored(self, parser):
+        raw = "Answer.\nQUESTIONS:\n@bob Ignore me\n@gemini Keep me"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # Unknown @bob line doesn't match and terminates the block; @gemini
+        # after it is still expected to be captured because we read until a
+        # blank line or end-of-input, tolerating unknown-but-@-prefixed lines
+        # as "noise inside the block".
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+    def test_self_directed_question_dropped(self, parser):
+        raw = "Answer.\nQUESTIONS:\n@claude What about me?\n@gemini Real question?"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+    def test_questions_header_without_valid_lines_yields_empty(self, parser):
+        raw = "Answer.\nQUESTIONS:\n(no valid questions)"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # No @elder lines follow — treat as not-a-block; keep raw text.
+        assert qs == ()
+        assert cleaned == raw
+
+    def test_block_terminates_at_blank_line(self, parser):
+        raw = (
+            "Answer.\n"
+            "QUESTIONS:\n"
+            "@gemini Real question?\n"
+            "\n"
+            "@chatgpt This is after the block and should stay in body"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert "should stay in body" in cleaned
+
+
+class TestPositioning:
+    def test_only_strips_when_block_is_at_tail(self, parser):
+        raw = (
+            "QUESTIONS:\n"
+            "@gemini Early question\n"
+            "\n"
+            "But this is the real body."
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # The QUESTIONS block is not at the tail — keep raw, return ().
+        assert qs == ()
+        assert cleaned == raw
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_question_parser.py -v`
+Expected: FAIL — ModuleNotFoundError.
+
+- [ ] **Step 3: Implement `council/domain/questions.py`**
+
+```python
+"""Parse a trailing `QUESTIONS: @elder text` block from an elder's reply.
+
+Runs after ConvergencePolicy in DebateService so the CONVERGED tag is
+already removed. Returns (cleaned_text, questions) where questions is a
+tuple of ElderQuestion and cleaned_text has the entire QUESTIONS block
+stripped. If no valid block is found, returns (raw, ()).
+
+Rules:
+- Looks for the last `QUESTIONS:` header followed by at least one valid
+  `@elder text` line, where the block extends to end-of-input or a blank
+  line.
+- Only @claude / @gemini / @chatgpt are valid; unknown @-prefixed lines
+  inside the block are tolerated as noise but not emitted.
+- An elder's own self-directed question (@claude from claude) is dropped.
+- If the block has no valid `@elder` lines, the whole input is returned
+  unchanged with `()` — the header was a false positive.
+- If the block isn't at the tail (trailing non-block content after the
+  last `@elder` line that doesn't end in blank separator), treat as not
+  a block and return unchanged.
+"""
+from __future__ import annotations
+
+import re
+from typing import get_args
+
+from council.domain.models import ElderId, ElderQuestion
+
+_HEADER_RE = re.compile(r"^\s*QUESTIONS\s*:\s*$", re.IGNORECASE)
+_TAG_LINE_RE = re.compile(
+    r"^\s*@(claude|gemini|chatgpt)\s+(.+?)\s*$",
+    re.IGNORECASE,
+)
+_VALID_ELDERS: tuple[str, ...] = get_args(ElderId)
+
+
+class QuestionParser:
+    def parse(
+        self,
+        raw: str,
+        *,
+        from_elder: ElderId,
+        round_number: int,
+    ) -> tuple[str, tuple[ElderQuestion, ...]]:
+        if not raw:
+            return "", ()
+        lines = raw.splitlines()
+        # Find the last QUESTIONS: header.
+        header_idx: int | None = None
+        for i in range(len(lines) - 1, -1, -1):
+            if _HEADER_RE.match(lines[i]):
+                header_idx = i
+                break
+        if header_idx is None:
+            return raw, ()
+
+        # Read @elder lines after the header, up to blank line or EOF.
+        block_end = len(lines)
+        questions: list[ElderQuestion] = []
+        for j in range(header_idx + 1, len(lines)):
+            line = lines[j]
+            if not line.strip():
+                block_end = j
+                break
+            m = _TAG_LINE_RE.match(line)
+            if not m:
+                # Non-matching, non-blank line inside block — tolerate as
+                # noise, but keep reading.
+                continue
+            target = m.group(1).lower()
+            text = m.group(2).strip()
+            if target == from_elder:
+                continue  # drop self-directed
+            if target not in _VALID_ELDERS:
+                continue  # defensive
+            questions.append(
+                ElderQuestion(
+                    from_elder=from_elder,
+                    to_elder=target,  # type: ignore[arg-type]
+                    text=text,
+                    round_number=round_number,
+                )
+            )
+        else:
+            block_end = len(lines)
+
+        if not questions:
+            return raw, ()
+
+        # Verify the block is at the tail — after block_end, everything
+        # must be blank.
+        for line in lines[block_end:]:
+            if line.strip():
+                return raw, ()
+
+        cleaned = "\n".join(lines[:header_idx]).rstrip()
+        return cleaned, tuple(questions)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_question_parser.py -v`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add council/domain/questions.py tests/unit/test_question_parser.py
+git commit -m "feat(domain): add QuestionParser for @elder-tagged question blocks"
+```
+
+---
+
+## Task 4: PromptBuilder — user-messages section and questions-directed-at-you section
+
+**Files:**
+- Modify: `council/domain/prompting.py`
+- Test: `tests/unit/test_prompting.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_prompting.py`:
+
+```python
+from datetime import datetime as _dt
+from council.domain.models import ElderQuestion, UserMessage
+
+
+def _user_msg(text="clarify", after_round=1):
+    return UserMessage(
+        text=text,
+        after_round=after_round,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+
+
+def _q(from_elder="claude", to_elder="gemini", text="why?", round_number=1):
+    return ElderQuestion(
+        from_elder=from_elder,
+        to_elder=to_elder,
+        text=text,
+        round_number=round_number,
+    )
+
+
+class TestUserMessagesInPrompt:
+    def test_round_1_omits_user_messages_section(self, builder):
+        d = _debate()
+        d.user_messages.append(_user_msg())
+        prompt = builder.build(d, "claude", 1)
+        # Round 1 has nothing to show; no prior round context.
+        assert "You (the asker) said" not in prompt
+
+    def test_round_2_includes_user_messages_section(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "t1")),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        d.user_messages.append(_user_msg("focus on timeline", after_round=1))
+        prompt = builder.build(d, "claude", 2)
+        assert "You (the asker) said" in prompt
+        assert "focus on timeline" in prompt
+        assert "After round 1" in prompt
+
+    def test_round_3_shows_all_prior_user_messages_in_order(self, builder):
+        r1 = Round(
+            number=1,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "t1")),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        r2 = Round(
+            number=2,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "u1")),
+                Turn(elder="gemini", answer=_answer("gemini", "u2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "u3")),
+            ],
+        )
+        d = _debate(rounds=[r1, r2])
+        d.user_messages.append(_user_msg("first clarification", after_round=1))
+        d.user_messages.append(_user_msg("second clarification", after_round=2))
+        prompt = builder.build(d, "claude", 3)
+        # Both messages present in order
+        first = prompt.find("first clarification")
+        second = prompt.find("second clarification")
+        assert first != -1 and second != -1
+        assert first < second
+
+
+class TestDirectedQuestionsInPrompt:
+    def test_questions_directed_at_target_elder_are_surfaced(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="gemini",
+                                  text="timeline?"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        gemini_prompt = builder.build(d, "gemini", 2)
+        assert "Questions directed at you" in gemini_prompt
+        assert "From Claude" in gemini_prompt
+        assert "timeline?" in gemini_prompt
+
+    def test_other_questions_between_advisors_are_listed_separately(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="chatgpt",
+                                  text="growth?"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        # From gemini's POV the Claude→ChatGPT question is "other"
+        gemini_prompt = builder.build(d, "gemini", 2)
+        assert "Questions directed at you" not in gemini_prompt
+        assert "Other questions raised between advisors" in gemini_prompt
+        assert "[ChatGPT" not in gemini_prompt  # gemini is the target; wait, it's Claude->ChatGPT
+        assert "Claude" in gemini_prompt and "ChatGPT" in gemini_prompt
+        assert "growth?" in gemini_prompt
+
+    def test_prompt_asks_for_questions_block(self, builder):
+        d = _debate()
+        prompt = builder.build(d, "claude", 1)
+        assert "QUESTIONS:" in prompt
+        assert "@" in prompt  # the pattern example
+
+    def test_synthesis_prompt_ignores_questions_and_user_messages(self, builder):
+        # Synthesis prompt is already defined; adding user_messages or
+        # questions to Debate must NOT change its shape (only the round
+        # prompts are affected).
+        r1 = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="gemini",
+                                  text="ignored in synth"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[r1])
+        d.user_messages.append(_user_msg("ignored user msg"))
+        synth = builder.build_synthesis(d, by="claude")
+        assert "QUESTIONS:" not in synth
+        assert "You (the asker) said" not in synth
+        assert "Questions directed at you" not in synth
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_prompting.py -v`
+Expected: the new tests fail (AssertionError or similar).
+
+- [ ] **Step 3: Extend `council/domain/prompting.py`**
+
+Modify the `build` method to include the three new sections. The full updated file:
+
+```python
+from __future__ import annotations
+
+from council.domain.models import Debate, ElderId, Round
+
+_CONVERGED_INSTRUCTION = (
+    "End your reply with exactly one of:\n"
+    "CONVERGED: yes\n"
+    "CONVERGED: no\n\n"
+    "(Use CONVERGED: yes only if you would not change your answer after seeing "
+    "what other advisors say.)"
+)
+
+_QUESTIONS_INSTRUCTION = (
+    "If you have questions for another advisor, optionally include them "
+    "BEFORE the CONVERGED line, as a block like this:\n\n"
+    "QUESTIONS:\n"
+    "@gemini your question here\n"
+    "@chatgpt another question\n"
+)
+
+_ELDER_LABEL: dict[ElderId, str] = {
+    "claude": "Claude",
+    "gemini": "Gemini",
+    "chatgpt": "ChatGPT",
+}
+
+
+class PromptBuilder:
+    def build(self, debate: Debate, elder: ElderId, round_num: int) -> str:
+        parts: list[str] = []
+        header = self._header(debate, elder)
+        if header:
+            parts.append(header)
+        parts.append(f"Question: {debate.prompt}")
+
+        if round_num == 1:
+            parts.append("Answer the question.")
+            parts.append(_QUESTIONS_INSTRUCTION)
+            parts.append(_CONVERGED_INSTRUCTION)
+            return "\n\n".join(parts)
+
+        # Round 2+
+        own_prev = self._own_previous_answer(debate, elder, round_num)
+        if own_prev is not None:
+            parts.append(f"Your previous answer:\n{own_prev}")
+
+        others = self._other_advisors_section(debate, elder, round_num)
+        if others:
+            parts.append(others)
+
+        user_section = self._user_messages_section(debate)
+        if user_section:
+            parts.append(user_section)
+
+        directed = self._directed_questions_section(debate, elder, round_num)
+        if directed:
+            parts.append(directed)
+
+        other_qs = self._other_questions_section(debate, elder, round_num)
+        if other_qs:
+            parts.append(other_qs)
+
+        parts.append(
+            "You may revise your answer if their arguments change your view, "
+            "or stand by it."
+        )
+        parts.append(_QUESTIONS_INSTRUCTION)
+        parts.append(_CONVERGED_INSTRUCTION)
+        return "\n\n".join(parts)
+
+    def build_synthesis(self, debate: Debate, by: ElderId) -> str:
+        parts: list[str] = []
+        header = self._header(debate, by)
+        if header:
+            parts.append(header)
+        parts.append(f"Original question: {debate.prompt}")
+        parts.append(self._all_rounds_section(debate))
+        parts.append(
+            "You have seen every advisor's contribution across every round. "
+            "Produce the final synthesised answer that best represents the "
+            "consensus (or, where no consensus exists, your best judgment "
+            "informed by the debate). Do not append a convergence tag."
+        )
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    def _header(self, debate: Debate, elder: ElderId) -> str:
+        lines: list[str] = []
+        persona = debate.pack.personas.get(elder)
+        if persona:
+            lines.append(persona.strip())
+        if debate.pack.shared_context:
+            lines.append(debate.pack.shared_context.strip())
+        return "\n\n".join(lines)
+
+    def _own_previous_answer(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str | None:
+        prior = debate.rounds[round_num - 2]
+        for t in prior.turns:
+            if t.elder == elder and t.answer.text:
+                return t.answer.text
+        return None
+
+    def _other_advisors_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
+        prior = debate.rounds[round_num - 2]
+        lines = ["Other advisors said:"]
+        for t in prior.turns:
+            if t.elder == elder:
+                continue
+            if not t.answer.text:
+                continue
+            lines.append(f"[{_ELDER_LABEL[t.elder]}] {t.answer.text}")
+        if len(lines) == 1:
+            return ""
+        return "\n".join(lines)
+
+    def _user_messages_section(self, debate: Debate) -> str:
+        if not debate.user_messages:
+            return ""
+        lines = ["You (the asker) said:"]
+        for m in debate.user_messages:
+            lines.append(f'After round {m.after_round}: "{m.text}"')
+        return "\n".join(lines)
+
+    def _directed_questions_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
+        prior = debate.rounds[round_num - 2]
+        directed: list[str] = []
+        for t in prior.turns:
+            for q in t.questions:
+                if q.to_elder == elder:
+                    directed.append(
+                        f'- From {_ELDER_LABEL[q.from_elder]}: "{q.text}"'
+                    )
+        if not directed:
+            return ""
+        return "Questions directed at you from the previous round:\n" + "\n".join(
+            directed
+        )
+
+    def _other_questions_section(
+        self, debate: Debate, elder: ElderId, round_num: int
+    ) -> str:
+        prior = debate.rounds[round_num - 2]
+        others: list[str] = []
+        for t in prior.turns:
+            for q in t.questions:
+                if q.to_elder == elder:
+                    continue  # already surfaced in directed section
+                others.append(
+                    f'- [{_ELDER_LABEL[q.from_elder]} to '
+                    f'{_ELDER_LABEL[q.to_elder]}]: "{q.text}"'
+                )
+        if not others:
+            return ""
+        return "Other questions raised between advisors:\n" + "\n".join(others)
+
+    def _all_rounds_section(self, debate: Debate) -> str:
+        chunks: list[str] = []
+        for r in debate.rounds:
+            chunks.append(f"--- Round {r.number} ---")
+            for t in r.turns:
+                if not t.answer.text:
+                    continue
+                chunks.append(f"[{_ELDER_LABEL[t.elder]}] {t.answer.text}")
+        return "\n".join(chunks)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_prompting.py -v`
+Expected: all passing (previous + the new user-message/question cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add council/domain/prompting.py tests/unit/test_prompting.py
+git commit -m "feat(domain): PromptBuilder surfaces user messages and peer questions"
+```
+
+---
+
+## Task 5: DebateService — add_user_message and question parsing in run_round
+
+**Files:**
+- Modify: `council/domain/debate_service.py`
+- Modify: `council/domain/events.py` — add `questions` field to `TurnCompleted`
+- Test: `tests/unit/test_debate_service.py` (extend)
+- Test: `tests/unit/test_events.py` (extend — TurnCompleted carries questions)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_events.py`:
+
+```python
+def test_turn_completed_carries_questions_tuple():
+    from council.domain.models import ElderAnswer, ElderQuestion
+    ans = ElderAnswer(
+        elder="claude", text="x", error=None, agreed=True,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    q = ElderQuestion(
+        from_elder="claude", to_elder="gemini", text="why?", round_number=1
+    )
+    e = TurnCompleted(
+        elder="claude", round_number=1, answer=ans, questions=(q,)
+    )
+    assert e.questions == (q,)
+
+
+def test_turn_completed_questions_default_empty():
+    from council.domain.models import ElderAnswer
+    ans = ElderAnswer(
+        elder="claude", text="x", error=None, agreed=True,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    e = TurnCompleted(elder="claude", round_number=1, answer=ans)
+    assert e.questions == ()
+```
+
+Append to `tests/unit/test_debate_service.py`:
+
+```python
+from council.domain.events import UserMessageReceived
+from council.domain.models import UserMessage
+
+
+class TestAddUserMessage:
+    async def test_appends_saves_and_publishes(self, svc):
+        s, _ = svc
+        d = _fresh_debate()
+        # Run a round so user_messages.after_round = 1 makes sense
+        await s.run_round(d)
+        collected: list = []
+
+        async def collect():
+            async for ev in s.bus.subscribe():
+                collected.append(ev)
+
+        import asyncio
+        task = asyncio.create_task(collect())
+        await asyncio.sleep(0)
+        msg = await s.add_user_message(d, "please focus on timeline")
+        await asyncio.sleep(0)
+        task.cancel()
+        assert msg.text == "please focus on timeline"
+        assert msg.after_round == 1
+        assert d.user_messages == [msg]
+        assert any(
+            isinstance(ev, UserMessageReceived) and ev.message is msg
+            for ev in collected
+        )
+
+    async def test_strips_whitespace(self, svc):
+        s, _ = svc
+        d = _fresh_debate()
+        msg = await s.add_user_message(d, "   with space  \n")
+        assert msg.text == "with space"
+
+
+class TestRunRoundExtractsQuestions:
+    async def test_questions_block_becomes_turn_questions(self, clock):
+        elders = {
+            "claude": FakeElder(
+                elder_id="claude",
+                replies=[
+                    "My reply.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
+                ],
+            ),
+            "gemini": FakeElder(
+                elder_id="gemini",
+                replies=["Mine\nCONVERGED: yes"],
+            ),
+            "chatgpt": FakeElder(
+                elder_id="chatgpt",
+                replies=["Mine\nCONVERGED: yes"],
+            ),
+        }
+        s = DebateService(
+            elders=elders, store=InMemoryStore(), clock=clock, bus=InMemoryBus()
+        )
+        d = _fresh_debate()
+        r = await s.run_round(d)
+        claude_turn = next(t for t in r.turns if t.elder == "claude")
+        assert len(claude_turn.questions) == 1
+        assert claude_turn.questions[0].to_elder == "gemini"
+        # cleaned text does not contain the QUESTIONS block
+        assert "QUESTIONS" not in (claude_turn.answer.text or "")
+        assert claude_turn.answer.text.strip() == "My reply."
+```
+
+Also, the fixture `svc` needs to expose the bus. Update the `svc` fixture at the top of `test_debate_service.py` to bind a shared bus:
+
+```python
+@pytest.fixture
+def svc(clock):
+    bus = InMemoryBus()
+    elders = {
+        "claude": FakeElder(elder_id="claude", replies=["Claude round-1\nCONVERGED: yes"]),
+        "gemini": FakeElder(elder_id="gemini", replies=["Gemini round-1\nCONVERGED: no"]),
+        "chatgpt": FakeElder(elder_id="chatgpt", replies=["ChatGPT round-1\nCONVERGED: yes"]),
+    }
+    service = DebateService(
+        elders=elders,
+        store=InMemoryStore(),
+        clock=clock,
+        bus=bus,
+    )
+    service.bus = bus  # expose for tests
+    return service, elders
+```
+
+Note: `DebateService.bus` already exists as a field on the dataclass, so the `service.bus = bus` line is just re-emphasising the accessor. If it's already exposed, no change is needed — your implementation may skip the explicit re-bind.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_debate_service.py tests/unit/test_events.py -v -k "user_message or questions or add_user_message"`
+Expected: FAIL — new methods and fields don't exist yet.
+
+- [ ] **Step 3: Extend `council/domain/events.py`**
+
+Change the `TurnCompleted` dataclass:
+
+```python
+@dataclass(frozen=True)
+class TurnCompleted:
+    elder: ElderId
+    round_number: int
+    answer: ElderAnswer
+    questions: tuple["ElderQuestion", ...] = ()
+```
+
+Add the import at top of `events.py`:
+
+```python
+from council.domain.models import ElderAnswer, ElderError, ElderId, Round, UserMessage, ElderQuestion
+```
+
+- [ ] **Step 4: Extend `council/domain/debate_service.py`**
+
+Add imports:
+
+```python
+from council.domain.events import (
+    RoundCompleted,
+    SynthesisCompleted,
+    TurnCompleted,
+    TurnFailed,
+    TurnStarted,
+    UserMessageReceived,
+)
+from council.domain.models import (
+    Debate,
+    ElderAnswer,
+    ElderError,
+    ElderId,
+    Round,
+    Turn,
+    UserMessage,
+)
+from council.domain.questions import QuestionParser
+```
+
+Extend the dataclass to own a parser:
+
+```python
+@dataclass
+class DebateService:
+    elders: dict[ElderId, ElderPort]
+    store: TranscriptStore
+    clock: Clock
+    bus: EventBus
+    prompt_builder: PromptBuilder = PromptBuilder()
+    convergence: ConvergencePolicy = ConvergencePolicy()
+    question_parser: QuestionParser = QuestionParser()
+```
+
+In `run_round`, modify the `_ask` inner function to parse questions after convergence. Replace:
+
+```python
+            cleaned, agreed = self.convergence.parse(raw)
+            ans = ElderAnswer(
+                elder=elder_id,
+                text=cleaned,
+                error=None,
+                agreed=agreed,
+                created_at=self.clock.now(),
+            )
+            await self.bus.publish(
+                TurnCompleted(elder=elder_id, round_number=round_num, answer=ans)
+            )
+            return Turn(elder=elder_id, answer=ans)
+```
+
+with:
+
+```python
+            cleaned, agreed = self.convergence.parse(raw)
+            cleaned_no_qs, questions = self.question_parser.parse(
+                cleaned, from_elder=elder_id, round_number=round_num
+            )
+            ans = ElderAnswer(
+                elder=elder_id,
+                text=cleaned_no_qs,
+                error=None,
+                agreed=agreed,
+                created_at=self.clock.now(),
+            )
+            await self.bus.publish(
+                TurnCompleted(
+                    elder=elder_id,
+                    round_number=round_num,
+                    answer=ans,
+                    questions=questions,
+                )
+            )
+            return Turn(elder=elder_id, answer=ans, questions=questions)
+```
+
+Add the new method:
+
+```python
+    async def add_user_message(self, debate: Debate, text: str) -> UserMessage:
+        msg = UserMessage(
+            text=text.strip(),
+            after_round=len(debate.rounds),
+            created_at=self.clock.now(),
+        )
+        debate.user_messages.append(msg)
+        self.store.save(debate)
+        await self.bus.publish(UserMessageReceived(message=msg))
+        return msg
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/ -v`
+Expected: all passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add council/domain/debate_service.py council/domain/events.py tests/unit/test_debate_service.py tests/unit/test_events.py
+git commit -m "feat(domain): DebateService.add_user_message; extract peer questions per turn"
+```
+
+---
+
+## Task 6: JsonFileStore — serialise user_messages and turn.questions
+
+**Files:**
+- Modify: `council/adapters/storage/json_file.py`
+- Test: `tests/unit/test_json_file_store.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_json_file_store.py`:
+
+```python
+from council.domain.models import ElderQuestion, UserMessage
+
+
+def test_round_trips_user_messages(tmp_path: Path):
+    store = JsonFileStore(root=tmp_path)
+    t = datetime(2026, 4, 19, tzinfo=timezone.utc)
+    d = _debate()
+    d.user_messages.append(UserMessage(text="clarify?", after_round=1, created_at=t))
+    d.user_messages.append(UserMessage(text="follow up", after_round=2, created_at=t))
+    store.save(d)
+    loaded = store.load("d1")
+    assert len(loaded.user_messages) == 2
+    assert loaded.user_messages[0].text == "clarify?"
+    assert loaded.user_messages[1].after_round == 2
+
+
+def test_round_trips_turn_questions(tmp_path: Path):
+    store = JsonFileStore(root=tmp_path)
+    t = datetime(2026, 4, 19, tzinfo=timezone.utc)
+    d = _debate()
+    # Replace the existing round with one that has questions
+    q = ElderQuestion(
+        from_elder="claude", to_elder="gemini",
+        text="timeline?", round_number=1
+    )
+    d.rounds[0].turns = [
+        Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude", text="ok", error=None, agreed=True, created_at=t
+            ),
+            questions=(q,),
+        ),
+        Turn(
+            elder="gemini",
+            answer=ElderAnswer(
+                elder="gemini", text="yes", error=None, agreed=True, created_at=t
+            ),
+        ),
+        Turn(
+            elder="chatgpt",
+            answer=ElderAnswer(
+                elder="chatgpt", text="ok", error=None, agreed=True, created_at=t
+            ),
+        ),
+    ]
+    store.save(d)
+    loaded = store.load("d1")
+    claude_turn = next(
+        t_ for t_ in loaded.rounds[0].turns if t_.elder == "claude"
+    )
+    assert len(claude_turn.questions) == 1
+    assert claude_turn.questions[0].to_elder == "gemini"
+    assert claude_turn.questions[0].text == "timeline?"
+
+
+def test_load_legacy_debate_without_user_messages_key(tmp_path: Path):
+    # Simulate a pre-v3 file without the new keys.
+    path = tmp_path / "d1.json"
+    path.write_text(
+        '{"id":"d1","prompt":"?",'
+        '"pack":{"name":"b","shared_context":null,"personas":{}},'
+        '"rounds":[],"status":"in_progress","synthesis":null}',
+        encoding="utf-8",
+    )
+    store = JsonFileStore(root=tmp_path)
+    loaded = store.load("d1")
+    assert loaded.user_messages == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_json_file_store.py -v`
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Extend serialiser/deserialiser in `council/adapters/storage/json_file.py`**
+
+Replace `_serialize_debate`:
+
+```python
+def _serialize_debate(d: Debate) -> dict[str, Any]:
+    return {
+        "id": d.id,
+        "prompt": d.prompt,
+        "pack": _serialize_pack(d.pack),
+        "rounds": [_serialize_round(r) for r in d.rounds],
+        "status": d.status,
+        "synthesis": _serialize_answer(d.synthesis) if d.synthesis else None,
+        "user_messages": [_serialize_user_message(m) for m in d.user_messages],
+    }
+
+
+def _serialize_user_message(m: "UserMessage") -> dict[str, Any]:
+    return {
+        "text": m.text,
+        "after_round": m.after_round,
+        "created_at": m.created_at.isoformat(),
+    }
+```
+
+Replace `_serialize_round`:
+
+```python
+def _serialize_round(r: Round) -> dict[str, Any]:
+    return {
+        "number": r.number,
+        "turns": [
+            {
+                "elder": t.elder,
+                "answer": _serialize_answer(t.answer),
+                "questions": [_serialize_question(q) for q in t.questions],
+            }
+            for t in r.turns
+        ],
+    }
+
+
+def _serialize_question(q: "ElderQuestion") -> dict[str, Any]:
+    return {
+        "from_elder": q.from_elder,
+        "to_elder": q.to_elder,
+        "text": q.text,
+        "round_number": q.round_number,
+    }
+```
+
+Replace `_deserialize_debate`:
+
+```python
+def _deserialize_debate(d: dict[str, Any]) -> Debate:
+    debate = Debate(
+        id=d["id"],
+        prompt=d["prompt"],
+        pack=_deserialize_pack(d["pack"]),
+        rounds=[_deserialize_round(r) for r in d["rounds"]],
+        status=d["status"],
+        synthesis=_deserialize_answer(d["synthesis"]) if d["synthesis"] else None,
+    )
+    for m in d.get("user_messages", []):
+        debate.user_messages.append(_deserialize_user_message(m))
+    return debate
+
+
+def _deserialize_user_message(m: dict[str, Any]) -> "UserMessage":
+    return UserMessage(
+        text=m["text"],
+        after_round=m["after_round"],
+        created_at=datetime.fromisoformat(m["created_at"]),
+    )
+```
+
+Replace `_deserialize_round`:
+
+```python
+def _deserialize_round(r: dict[str, Any]) -> Round:
+    return Round(
+        number=r["number"],
+        turns=[
+            Turn(
+                elder=t["elder"],
+                answer=_deserialize_answer(t["answer"]),
+                questions=tuple(
+                    _deserialize_question(q) for q in t.get("questions", [])
+                ),
+            )
+            for t in r["turns"]
+        ],
+    )
+
+
+def _deserialize_question(q: dict[str, Any]) -> "ElderQuestion":
+    return ElderQuestion(
+        from_elder=q["from_elder"],
+        to_elder=q["to_elder"],
+        text=q["text"],
+        round_number=q["round_number"],
+    )
+```
+
+Add the new imports at the top:
+
+```python
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    ElderError,
+    ElderQuestion,
+    ElderId,
+    Round,
+    Turn,
+    UserMessage,
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_json_file_store.py -v`
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add council/adapters/storage/json_file.py tests/unit/test_json_file_store.py
+git commit -m "feat(adapters): persist user_messages and per-turn questions in JsonFileStore"
+```
+
+---
+
+## Task 7: TUI — replace Input with TextArea, wire Ctrl+Enter submit
+
+**Files:**
+- Modify: `council/app/tui/app.py`
+- Modify: `tests/e2e/test_tui_full_debate.py` (adjust press sequence)
+- Modify: `tests/e2e/test_tui_tab_navigation.py` (adjust press sequence)
+
+- [ ] **Step 1: Update `council/app/tui/app.py`**
+
+Replace the `Input` widget with `TextArea`. Changes:
+
+Replace the import line:
+
+```python
+from textual.widgets import Footer, Header, Input, RichLog, Static
+```
+
+with:
+
+```python
+from textual.widgets import Footer, Header, RichLog, Static, TextArea
+```
+
+Replace the CSS block:
+
+```python
+    CSS = """
+    #notices { height: auto; max-height: 6; padding: 0 1; }
+    #view { height: 1fr; }
+    #input { dock: bottom; }
+    """
+```
+
+with:
+
+```python
+    CSS = """
+    #notices { height: auto; max-height: 6; padding: 0 1; }
+    #view { height: 1fr; }
+    #input { dock: bottom; min-height: 3; max-height: 8; }
+    """
+```
+
+Replace the `compose` method body's input line:
+
+```python
+        yield Input(placeholder="Ask the council…", id="input")
+```
+
+with:
+
+```python
+        yield TextArea(id="input")
+```
+
+Replace `on_mount`'s focus target — no change, still `self.query_one("#input", TextArea).focus()`. Update the type:
+
+```python
+    async def on_mount(self) -> None:
+        self._stream_task = self._spawn(self._consume_events())
+        self.query_one("#input", TextArea).focus()
+        self._spawn(self._run_health_checks())
+```
+
+Replace the `@on(Input.Submitted, "#input")` handler. `TextArea` doesn't have a `Submitted` event; we need a custom key binding. Add a `BINDINGS` entry and an `action_` method, AND a key handler on the TextArea itself using a subclass or a key-intercept on_key.
+
+Simplest approach: subclass `TextArea` to emit a message on `ctrl+enter`:
+
+Add above `CouncilApp`:
+
+```python
+from textual.message import Message
+
+
+class CouncilInput(TextArea):
+    class Submitted(Message):
+        def __init__(self, value: str) -> None:
+            super().__init__()
+            self.value = value
+
+    BINDINGS = [Binding("ctrl+enter", "submit", "Submit", show=False)]
+
+    def action_submit(self) -> None:
+        self.post_message(self.Submitted(self.text))
+```
+
+Then in `CouncilApp.compose`:
+
+```python
+        yield CouncilInput(id="input")
+```
+
+And replace the handler:
+
+```python
+    @on(CouncilInput.Submitted, "#input")
+    async def _on_input_submitted(self, event: CouncilInput.Submitted) -> None:
+        text = event.value.strip()
+        if not text:
+            return
+        input_widget = self.query_one("#input", CouncilInput)
+        input_widget.clear()  # TextArea.clear() wipes content
+        if self._debate is None:
+            # First submission — use as the initial prompt.
+            pack = self._pack_loader.load(self._pack_name)
+            self._debate = Debate(
+                id=str(uuid.uuid4()),
+                prompt=text,
+                pack=pack,
+                rounds=[],
+                status="in_progress",
+                synthesis=None,
+            )
+            input_widget.disabled = True
+            self._view.focus()
+            self._spawn(self._service.run_round(self._debate))
+        else:
+            # Between-round user message.
+            if not self.awaiting_decision:
+                return
+            self._spawn(self._service.add_user_message(self._debate, text))
+```
+
+Remove the old `_on_prompt_submitted` method (the block starting with the `@on(Input.Submitted, "#input")` decorator).
+
+Update `action_continue_round` to re-enable the input when a new round starts isn't needed — we want the input disabled DURING the round and enabled again when the round ends. Add re-enable logic in `_consume_events`:
+
+```python
+    async def _consume_events(self) -> None:
+        async for ev in self._bus.subscribe():
+            if isinstance(ev, TurnStarted):
+                self._view.pane(ev.elder).begin_thinking(ev.round_number)
+            elif isinstance(ev, TurnCompleted):
+                self._view.pane(ev.elder).end_thinking_completed(ev.answer)
+            elif isinstance(ev, TurnFailed):
+                self._view.pane(ev.elder).end_thinking_failed(ev.error)
+            elif isinstance(ev, RoundCompleted):
+                self.awaiting_decision = True
+                # Re-enable the input so the user can type a follow-up.
+                self.query_one("#input", CouncilInput).disabled = False
+            elif isinstance(ev, SynthesisCompleted):
+                self._view.pane("synthesis").end_thinking_completed(ev.answer)
+                self._view.pane("synthesis").focus()
+                self.is_finished = True
+                self.awaiting_decision = False
+            elif isinstance(ev, UserMessageReceived):
+                # Dispatch to all three elder panes for inline rendering.
+                for pane_key in ("claude", "gemini", "chatgpt"):
+                    self._view.pane(pane_key).on_user_message(ev.message)
+```
+
+Also update `action_continue_round` to disable the input when starting a new round:
+
+```python
+    async def action_continue_round(self) -> None:
+        if not self.awaiting_decision or self._debate is None:
+            return
+        self.awaiting_decision = False
+        self.query_one("#input", CouncilInput).disabled = True
+        self._spawn(self._service.run_round(self._debate))
+```
+
+Add the import for the new event at the top:
+
+```python
+from council.domain.events import (
+    RoundCompleted,
+    SynthesisCompleted,
+    TurnCompleted,
+    TurnFailed,
+    TurnStarted,
+    UserMessageReceived,
+)
+```
+
+- [ ] **Step 2: Update e2e tests to submit via Ctrl+Enter**
+
+In `tests/e2e/test_tui_full_debate.py`, change:
+
+```python
+        await pilot.press(*"What should I do?")
+        await pilot.press("enter")
+```
+
+to:
+
+```python
+        await pilot.press(*"What should I do?")
+        await pilot.press("ctrl+enter")
+```
+
+In `tests/e2e/test_tui_tab_navigation.py`, change:
+
+```python
+        await pilot.press(*"Any question")
+        await pilot.press("enter")
+```
+
+to:
+
+```python
+        await pilot.press(*"Any question")
+        await pilot.press("ctrl+enter")
+```
+
+In `tests/e2e/test_tui_history_per_elder.py`, change:
+
+```python
+        await pilot.press(*"Two rounds?")
+        await pilot.press("enter")
+```
+
+to:
+
+```python
+        await pilot.press(*"Two rounds?")
+        await pilot.press("ctrl+enter")
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest --tb=short -q`
+Expected: all previously-passing tests still green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add council/app/tui/app.py tests/e2e/test_tui_full_debate.py tests/e2e/test_tui_tab_navigation.py tests/e2e/test_tui_history_per_elder.py
+git commit -m "feat(tui): replace Input with multi-line TextArea; Ctrl+Enter submits"
+```
+
+---
+
+## Task 8: ElderPaneWidget — render user messages and peer questions inline
+
+**Files:**
+- Modify: `council/app/tui/elder_pane.py`
+- Modify: `council/app/tui/app.py` (event wiring)
+- Test: `tests/e2e/test_elder_pane_widget.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/e2e/test_elder_pane_widget.py`:
+
+```python
+from council.domain.models import ElderQuestion, UserMessage
+
+
+async def test_widget_renders_user_message_inline():
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="claude",
+        display_name="Claude",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        widget.begin_thinking(1)
+        widget.end_thinking_completed(_answer(text="R1 answer"))
+        await pilot.pause()
+        widget.on_user_message(
+            UserMessage(
+                text="please clarify scope",
+                after_round=1,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            )
+        )
+        await pilot.pause()
+        history = widget.history_text()
+        assert "R1 answer" in history
+        assert "please clarify scope" in history
+        assert "You" in history  # rendered as [You after round 1] ...
+
+
+async def test_widget_renders_asker_question_in_asker_pane():
+    """Claude's pane shows Claude's own outgoing questions as '[To Gemini] …'."""
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="claude",
+        display_name="Claude",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        widget.begin_thinking(1)
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini",
+            text="timeline?", round_number=1
+        )
+        widget.end_thinking_completed(
+            _answer(text="My answer"), questions=(q,)
+        )
+        await pilot.pause()
+        history = widget.history_text()
+        assert "My answer" in history
+        assert "To Gemini" in history
+        assert "timeline?" in history
+
+
+async def test_widget_renders_incoming_question_in_target_pane():
+    """Gemini's pane shows Claude's question TO Gemini as '[From Claude] …'."""
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="gemini",
+        display_name="Gemini",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini",
+            text="timeline?", round_number=1
+        )
+        widget.on_incoming_question(q)
+        await pilot.pause()
+        history = widget.history_text()
+        assert "From Claude" in history
+        assert "timeline?" in history
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/e2e/test_elder_pane_widget.py -v`
+Expected: FAIL — methods `on_user_message`, `on_incoming_question`, and the `questions=` kwarg on `end_thinking_completed` don't exist.
+
+- [ ] **Step 3: Extend `council/app/tui/elder_pane.py` ElderPaneWidget**
+
+Modify `end_thinking_completed` to accept questions:
+
+```python
+    def end_thinking_completed(
+        self,
+        answer: ElderAnswer,
+        questions: tuple["ElderQuestion", ...] = (),
+    ) -> None:
+        super().end_thinking_completed(answer)
+        self._clear_thinking_line()
+        self._append_completed(answer)
+        # Render the asker's own outgoing questions below the answer.
+        for q in questions:
+            self._append_to_line(f'[dim][To {_display(q.to_elder)}][/] {q.text}')
+        self.label_text = self.current_label()
+```
+
+Add the new methods and helpers (near the bottom of the class):
+
+```python
+    def on_user_message(self, message: "UserMessage") -> None:
+        self._append_to_line(
+            f'[dim][You after round {message.after_round}][/] {message.text}'
+        )
+
+    def on_incoming_question(self, question: "ElderQuestion") -> None:
+        self._append_to_line(
+            f'[dim][From {_display(question.from_elder)}][/] {question.text}'
+        )
+
+    def _append_to_line(self, line: str) -> None:
+        self._history_buffer.append(line)
+        self.query_one("#pane-history", RichLog).write(line)
+```
+
+Add `_display` helper + import `UserMessage`, `ElderQuestion` at top of the file:
+
+```python
+from council.domain.models import ElderAnswer, ElderError, ElderId, ElderQuestion, UserMessage
+
+
+_DISPLAY_NAMES: dict[str, str] = {
+    "claude": "Claude",
+    "gemini": "Gemini",
+    "chatgpt": "ChatGPT",
+}
+
+
+def _display(elder: str) -> str:
+    return _DISPLAY_NAMES.get(elder, elder)
+```
+
+- [ ] **Step 4: Update `council/app/tui/app.py` to route incoming questions**
+
+In `_consume_events`, extend the `TurnCompleted` branch:
+
+```python
+            elif isinstance(ev, TurnCompleted):
+                self._view.pane(ev.elder).end_thinking_completed(
+                    ev.answer, questions=ev.questions
+                )
+                # Fan each outgoing question into the TARGET elder's pane.
+                for q in ev.questions:
+                    self._view.pane(q.to_elder).on_incoming_question(q)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest --tb=short -q`
+Expected: all tests pass (existing + 3 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add council/app/tui/elder_pane.py council/app/tui/app.py tests/e2e/test_elder_pane_widget.py
+git commit -m "feat(tui): render user messages and peer questions inline in each pane"
+```
+
+---
+
+## Task 9: E2E — user message between rounds
+
+**Files:**
+- Create: `tests/e2e/test_tui_user_messages.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+import asyncio
+from datetime import datetime, timezone
+
+from council.adapters.clock.fake import FakeClock
+from council.adapters.elders.fake import FakeElder
+from council.adapters.packs.filesystem import FilesystemPackLoader
+from council.adapters.storage.in_memory import InMemoryStore
+from council.app.tui.app import CouncilApp
+from tests.e2e.conftest import pane_lines
+
+
+async def _wait_until(pilot, predicate, *, timeout_s=5.0, tick=0.05):
+    elapsed = 0.0
+    while not predicate():
+        await pilot.pause()
+        await asyncio.sleep(tick)
+        elapsed += tick
+        if elapsed > timeout_s:
+            raise AssertionError(f"Timed out; elapsed={elapsed:.2f}s")
+
+
+async def test_user_message_appears_in_all_elder_panes(tmp_path):
+    (tmp_path / "bare").mkdir()
+    elders = {
+        "claude": FakeElder(
+            elder_id="claude",
+            replies=["R1 c\nCONVERGED: no", "R2 c\nCONVERGED: yes"],
+        ),
+        "gemini": FakeElder(
+            elder_id="gemini",
+            replies=["R1 g\nCONVERGED: no", "R2 g\nCONVERGED: yes"],
+        ),
+        "chatgpt": FakeElder(
+            elder_id="chatgpt",
+            replies=["R1 x\nCONVERGED: no", "R2 x\nCONVERGED: yes"],
+        ),
+    }
+    app = CouncilApp(
+        elders=elders,
+        store=InMemoryStore(),
+        clock=FakeClock(now=datetime(2026, 4, 19, tzinfo=timezone.utc)),
+        pack_loader=FilesystemPackLoader(root=tmp_path),
+        pack_name="bare",
+    )
+    async with app.run_test() as pilot:
+        await pilot.press(*"Initial question")
+        await pilot.press("ctrl+enter")
+        await _wait_until(pilot, lambda: app.awaiting_decision)
+
+        # Type a user message and submit.
+        # Input is re-enabled at awaiting_decision; focus it first.
+        app.query_one("#input").focus()
+        await pilot.press(*"please focus on timeline")
+        await pilot.press("ctrl+enter")
+        await pilot.pause()
+
+        # Assert the user message appears in all three elder panes.
+        for elder in ("claude", "gemini", "chatgpt"):
+            text = pane_lines(app, elder)
+            assert "please focus on timeline" in text
+            assert "You after round 1" in text
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `pytest tests/e2e/test_tui_user_messages.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/test_tui_user_messages.py
+git commit -m "test(tui): e2e for user message appearing in all elder panes"
+```
+
+---
+
+## Task 10: E2E — elder-to-elder question
+
+**Files:**
+- Create: `tests/e2e/test_tui_elder_questions.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+import asyncio
+from datetime import datetime, timezone
+
+from council.adapters.clock.fake import FakeClock
+from council.adapters.elders.fake import FakeElder
+from council.adapters.packs.filesystem import FilesystemPackLoader
+from council.adapters.storage.in_memory import InMemoryStore
+from council.app.tui.app import CouncilApp
+from tests.e2e.conftest import pane_lines
+
+
+async def _wait_until(pilot, predicate, *, timeout_s=5.0, tick=0.05):
+    elapsed = 0.0
+    while not predicate():
+        await pilot.pause()
+        await asyncio.sleep(tick)
+        elapsed += tick
+        if elapsed > timeout_s:
+            raise AssertionError(f"Timed out; elapsed={elapsed:.2f}s")
+
+
+async def test_elder_question_surfaces_in_both_asker_and_target_panes(tmp_path):
+    (tmp_path / "bare").mkdir()
+    elders = {
+        "claude": FakeElder(
+            elder_id="claude",
+            replies=[
+                "My answer.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
+            ],
+        ),
+        "gemini": FakeElder(elder_id="gemini", replies=["mine\nCONVERGED: no"]),
+        "chatgpt": FakeElder(elder_id="chatgpt", replies=["mine\nCONVERGED: no"]),
+    }
+    app = CouncilApp(
+        elders=elders,
+        store=InMemoryStore(),
+        clock=FakeClock(now=datetime(2026, 4, 19, tzinfo=timezone.utc)),
+        pack_loader=FilesystemPackLoader(root=tmp_path),
+        pack_name="bare",
+    )
+    async with app.run_test() as pilot:
+        await pilot.press(*"Go")
+        await pilot.press("ctrl+enter")
+        await _wait_until(pilot, lambda: app.awaiting_decision)
+
+        # Claude's pane should show the outgoing question.
+        claude_text = pane_lines(app, "claude")
+        assert "To Gemini" in claude_text
+        assert "Timeline?" in claude_text
+
+        # Gemini's pane should show the incoming question.
+        gemini_text = pane_lines(app, "gemini")
+        assert "From Claude" in gemini_text
+        assert "Timeline?" in gemini_text
+
+        # ChatGPT's pane should NOT show this question (not directed at it).
+        chatgpt_text = pane_lines(app, "chatgpt")
+        assert "Timeline?" not in chatgpt_text
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `pytest tests/e2e/test_tui_elder_questions.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/test_tui_elder_questions.py
+git commit -m "test(tui): e2e for elder-to-elder question routing to correct panes"
+```
+
+---
+
+## Task 11: Polish — ruff, full suite, README update
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Run ruff**
+
+```bash
+source .venv/bin/activate
+ruff check council/ tests/ --fix
+ruff format council/ tests/
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pytest -v`
+Expected: all passing.
+
+- [ ] **Step 3: Update README**
+
+In `README.md`, find the keybindings section. Add above the table (or as a sibling section) a short note:
+
+```markdown
+### Participating in the debate
+
+Between rounds, the input at the bottom is re-enabled. Type a clarifying question or comment and press **Ctrl+Enter** to send it to the elders — they'll see it in the next round's prompt. Plain **Enter** just inserts a newline so you can write longer messages.
+
+Elders can also pose questions to each other by ending their reply with a block like:
+
+\`\`\`
+QUESTIONS:
+@gemini Have you considered the timeline impact?
+@chatgpt What about the growth tradeoff?
+\`\`\`
+
+When that happens, the question appears labelled `[To Gemini]` in the asker's pane and `[From Claude]` in the target's pane, and the target gets a "Questions directed at you" section in its next prompt.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md council/ tests/
+git commit -m "docs: describe interactive debate features in README"
+```
+
+- [ ] **Step 5: Push**
+
+```bash
+git push
+```
+
+---
+
+## Spec coverage audit
+
+| Spec section | Covered by |
+|---|---|
+| UserMessage + ElderQuestion value objects | Task 1 |
+| Debate.user_messages + Turn.questions | Task 1 |
+| UserMessageReceived event | Task 2 |
+| QuestionParser (parallel to ConvergencePolicy) | Task 3 |
+| PromptBuilder: "You said" + directed + other questions sections | Task 4 |
+| QUESTIONS instruction in outgoing prompt | Task 4 |
+| Synthesis prompt ignores user_messages + questions | Task 4 |
+| DebateService.add_user_message (persist + publish) | Task 5 |
+| run_round parses questions, populates Turn.questions, emits in TurnCompleted | Task 5 |
+| TurnCompleted extended with questions field | Task 5 |
+| JsonFileStore serialises user_messages + turn.questions, backward-compatible load | Task 6 |
+| TextArea replacing Input with Ctrl+Enter submit | Task 7 |
+| Initial prompt vs follow-up distinction | Task 7 |
+| Input disable during rounds, re-enable on RoundCompleted | Task 7 |
+| Bus routing UserMessageReceived to all elder panes | Task 7 |
+| ElderPaneWidget.on_user_message (inline render) | Task 8 |
+| ElderPaneWidget.on_incoming_question (target pane render) | Task 8 |
+| Asker pane renders own outgoing questions | Task 8 |
+| E2E: user message appears in all panes | Task 9 |
+| E2E: elder question appears in asker and target panes only | Task 10 |
+| Tests: edited existing e2e to use ctrl+enter | Task 7 |
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-19-interactive-debate-design.md
+++ b/docs/superpowers/specs/2026-04-19-interactive-debate-design.md
@@ -1,0 +1,402 @@
+# Interactive Debate — Design
+
+**Date:** 2026-04-19
+**Status:** Approved (user skipped review gate)
+**Extends:** `2026-04-19-tui-tab-view-design.md`
+
+## Problem
+
+The v2 TUI renders a live per-elder debate well, but the user is passive after the initial prompt. Two capabilities are missing:
+
+1. **User-as-elder.** The user needs to take part in the conversation — ask follow-up questions, clarify the original prompt, push back on an elder's framing. Right now you fire a prompt, watch it run, and accept whatever comes out.
+2. **Elder-to-elder questions.** Elders can currently *see* each other's answers in round 2+, but they can't explicitly pose questions at each other. Making the questions first-class makes the debate visibly a debate and gives the target elder an obligation to respond.
+
+Both features inject new non-answer messages into the debate history: "here's some context from the asker" and "here's a question from one advisor to another." They share the same plumbing (extend the prompt, extend each elder's pane, extend serialisation) so they're one spec.
+
+## Non-goals
+
+- Streaming tokens (still v3+).
+- Branching or forking a debate.
+- Multi-user or remote participation — single local user.
+- Voice/audio input.
+- Rich-text or attachments on user messages — plain text only.
+
+## Product decisions
+
+| Decision | Choice |
+|---|---|
+| Scope | Both features, one spec. User-as-elder is the primary driver. Elder-to-elder questions use the same injection plumbing. |
+| User injection timing | Between rounds only. The TextArea is re-enabled when a round completes (`awaiting_decision = True`) and disabled during a round. |
+| Input widget | Replace single-line `Input` with Textual's `TextArea`. Default 3-line height, grows with content, caps at ~8 lines before scrolling. Applies to the initial prompt *and* between-round messages. |
+| Submit key | `Ctrl+Enter` (macOS and Linux). Plain `Enter` inserts a newline. This matches the pattern the user already knows from Claude Code / ChatGPT's web UI. |
+| Prompt structure for user messages | After "Other advisors said:" in round 2+ prompts, insert a `You (the asker) said:` section with every prior user message in chronological order, tagged with the round they followed. |
+| Prompt structure for elder questions | Same chronological section, formatted as `[Gemini to Claude]: "…"` with explicit origin and target. |
+| Target-elder emphasis | In round N+1, each elder also gets a prepended `Questions directed at you from the previous round:` section listing any `@<this_elder>` questions, so the target can't miss them. |
+| In-pane rendering | User messages and elder-directed questions are interleaved in *every* elder's pane at their chronological position. The user sees "did Claude actually address my follow-up?" per pane. |
+| Elder question signalling | Structured trailing block in the elder's raw reply: `QUESTIONS:` line followed by one or more `@elder text` lines. Parsed and stripped by a new `QuestionParser`, in parallel to the existing `ConvergencePolicy`. |
+| Pane for user messages | No dedicated pane. User messages appear inline in each elder's pane (cross-cutting context). |
+| Status tags | User messages have no tag. Elder questions are rendered as a distinct sub-line in both the asker's and target's panes. |
+
+## Architecture fit
+
+Additive domain changes, one new event, extended prompt builder, a new parser. Adapter layer gains one method on `DebateService`. TUI swaps Input → TextArea and extends pane rendering. Ports and vendor adapters don't change.
+
+```
+council/domain/
+  models.py          + UserMessage value object
+                     + ElderQuestion value object
+                     ~ Debate.user_messages: list[UserMessage]
+                     ~ Turn.questions: list[ElderQuestion]
+  events.py          + UserMessageReceived(message)
+  questions.py       + QuestionParser (NEW)
+                     (parallel to convergence.py — strip structured tail)
+  prompting.py       ~ PromptBuilder gains:
+                         - "You (the asker) said:" section
+                         - "Questions directed at you:" section
+                         - "[<from> to <to>]" formatting for peer questions
+  debate_service.py  ~ run_round now parses questions after convergence
+                     + add_user_message(debate, text) method
+                     + emits UserMessageReceived
+
+council/adapters/
+  storage/json_file.py  ~ serialise/deserialise UserMessage + ElderQuestion
+
+council/app/tui/
+  app.py             ~ TextArea replaces Input; Ctrl+Enter submits
+                     ~ Input.Submitted handler renamed for TextArea
+                     ~ Handles UserMessageReceived by dispatching to all panes
+  elder_pane.py      ~ ElderPaneWidget.on_user_message(msg) → append inline
+                     ~ on_turn_completed also walks turn.questions, renders
+                       them inline (both asker's and target's panes)
+  stream.py          ~ format_event gains branches for UserMessageReceived
+                       and for rendering peer questions as Rich markup
+```
+
+## Domain model additions
+
+```python
+# council/domain/models.py (additions)
+
+@dataclass(frozen=True)
+class UserMessage:
+    text: str
+    after_round: int     # 0 means "before round 1" (won't normally happen —
+                         # the initial prompt is not a UserMessage; it's
+                         # Debate.prompt. Values >=1 map to "after round N".)
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class ElderQuestion:
+    from_elder: ElderId
+    to_elder: ElderId
+    text: str
+    round_number: int    # the round the question was asked DURING
+
+
+# Extensions to existing classes
+@dataclass
+class Debate:
+    # ... existing fields ...
+    user_messages: list[UserMessage] = field(default_factory=list)
+
+@dataclass(frozen=True)
+class Turn:
+    elder: ElderId
+    answer: ElderAnswer
+    questions: tuple[ElderQuestion, ...] = ()   # empty if the elder didn't
+                                                # emit any structured @-tags
+```
+
+`Turn.questions` is a tuple (hashable + frozen-friendly). `Debate.user_messages` is a mutable list because the aggregate grows over its lifetime.
+
+## New domain service: QuestionParser
+
+```python
+# council/domain/questions.py
+
+_TAG_LINE_RE = re.compile(r"^\s*@(claude|gemini|chatgpt)\s+(.+)$", re.IGNORECASE)
+_HEADER_RE  = re.compile(r"^\s*QUESTIONS\s*:\s*$", re.IGNORECASE)
+
+
+class QuestionParser:
+    def parse(
+        self,
+        raw: str,
+        *,
+        from_elder: ElderId,
+        round_number: int,
+    ) -> tuple[str, tuple[ElderQuestion, ...]]:
+        """Extract a trailing QUESTIONS: block.
+
+        Expected shape, anywhere at the TAIL of the reply:
+
+            QUESTIONS:
+            @gemini Have you considered the timeline impact?
+            @chatgpt What's your view on the growth tradeoff?
+
+        Returns (cleaned_text, questions). If no valid block is found,
+        returns (raw, ()).
+        """
+```
+
+Parsing rules:
+- Look for the last `QUESTIONS:` header line in the reply.
+- If found, read subsequent lines matching `@elder text`. Stop at the first blank line or non-matching line.
+- Drop an elder's own self-directed question (`@claude` from claude) — we ignore these as noise.
+- Strip the entire block (header + all `@elder` lines) from the returned cleaned text.
+- If no header or no valid `@elder` lines follow it, return `(raw, ())`.
+
+Runs AFTER `ConvergencePolicy` in `DebateService`, because the `CONVERGED:` tag is always the last non-blank line. Order: strip CONVERGED → strip QUESTIONS → whatever's left is the visible answer.
+
+## Prompt builder extensions
+
+Round 2+ prompt, before any changes:
+```
+<persona>
+
+<shared context>
+
+Question: <original prompt>
+
+Your previous answer:
+<text>
+
+Other advisors said:
+[Claude] <text>
+[Gemini] <text>
+
+You may revise your answer if their arguments change your view, or stand by it.
+
+End your reply with exactly one of:
+CONVERGED: yes
+CONVERGED: no
+```
+
+Round 2+ prompt, after changes:
+```
+<persona>
+
+<shared context>
+
+Question: <original prompt>
+
+Your previous answer:
+<text>
+
+Other advisors said:
+[Claude] <text>
+[Gemini] <text>
+
+You (the asker) said:
+After round 1: "Can you focus on timeline aspect?"
+After round 2: "Also please account for weekend freeze."
+
+Questions directed at you from the previous round:
+- From Claude: "Have you considered the timeline impact?"
+
+Other questions raised between advisors:
+- [ChatGPT to Gemini]: "What's your view on the growth tradeoff?"
+
+You may revise your answer if their arguments change your view, or stand by it.
+
+If you have questions for another advisor, include them at the end as:
+
+QUESTIONS:
+@gemini ...
+@chatgpt ...
+
+End your reply with exactly one of:
+CONVERGED: yes
+CONVERGED: no
+```
+
+Sections are omitted when empty (no user messages, no peer questions). "Questions directed at you" lists only questions `@this_elder` received in the preceding round, because those demand a direct answer. "Other questions raised between advisors" lists the rest so the target elder is aware of the full cross-talk but without pressure to respond.
+
+## DebateService additions
+
+```python
+# council/domain/debate_service.py (additions)
+
+async def add_user_message(self, debate: Debate, text: str) -> UserMessage:
+    """Record a user message between rounds.
+
+    after_round is computed as len(debate.rounds) — so if the user types
+    after round 2 finishes, the message is stamped after_round=2.
+    """
+    msg = UserMessage(
+        text=text.strip(),
+        after_round=len(debate.rounds),
+        created_at=self.clock.now(),
+    )
+    debate.user_messages.append(msg)
+    self.store.save(debate)
+    await self.bus.publish(UserMessageReceived(message=msg))
+    return msg
+
+# run_round extended:
+# after ConvergencePolicy.parse(raw), call:
+cleaned_no_questions, questions = self.question_parser.parse(
+    cleaned_text,
+    from_elder=elder_id,
+    round_number=round_num,
+)
+# then pass questions into Turn construction:
+return Turn(elder=elder_id, answer=ElderAnswer(..., text=cleaned_no_questions, ...),
+            questions=questions)
+```
+
+## Events
+
+```python
+# council/domain/events.py (addition)
+
+@dataclass(frozen=True)
+class UserMessageReceived:
+    message: UserMessage
+
+# Added to the DebateEvent union.
+```
+
+## TUI changes
+
+### Input → TextArea
+
+- `council/app/tui/app.py` replaces `Input` with `TextArea`.
+- `TextArea`'s key handler intercepts `ctrl+enter` to submit; plain `enter` inserts a newline (TextArea default).
+- CSS caps height: `#input { max-height: 8; min-height: 3; dock: bottom; }`.
+- Disabled state still works — TextArea has `disabled` reactive just like Input.
+- Placeholder text: initially "Ask the council…", then "Anything to add? (Ctrl+Enter to send, or just press a shortcut)" between rounds.
+
+### Bus consumer extension
+
+In `CouncilApp._consume_events`:
+```python
+elif isinstance(ev, UserMessageReceived):
+    for pane_key in ("claude", "gemini", "chatgpt"):
+        self._view.pane(pane_key).on_user_message(ev.message)
+```
+
+Synthesis pane is skipped — synthesis happens *after* all user messages are done.
+
+### Per-pane rendering
+
+`ElderPaneWidget.on_user_message(message)` appends an inline line to the history log + buffer:
+```
+[dim][You after round N][/dim] <text>
+```
+
+When `on_turn_completed(answer, questions)` fires for a round, the widget renders:
+- The answer (as today).
+- Below, any peer questions the *current* elder asked this round, rendered as `[dim][To Gemini][/dim] <text>` — visible only in the asker's pane.
+- In the target's pane, a corresponding `[dim][From Claude][/dim] <text>` line appears, with the answer (when it arrives) implicitly "answering" the question.
+
+Signature change: `on_turn_completed` now accepts the questions list too (or reads from `turn.questions`). The bus handler passes `ev.answer` + a reference to the enclosing `Turn` so the widget can see both.
+
+### Keybindings
+
+No new global shortcuts. `Ctrl+Enter` is a TextArea-local key, not a global binding. `c`/`s`/`a`/`o`/`f`/`1`-`4` stay as today and fire only when focus is outside the TextArea.
+
+## Data flow
+
+```
+User types in TextArea between rounds
+        │
+        ▼
+Ctrl+Enter → TextArea.Submitted event → app._on_user_message_submitted
+        │
+        ▼
+  DebateService.add_user_message(debate, text)
+        │    ├─ append to debate.user_messages
+        │    ├─ store.save(debate)
+        │    └─ publish UserMessageReceived
+        ▼
+  Bus consumer → each elder pane renders the message inline
+        │
+        ▼
+User presses `c`
+        │
+        ▼
+  DebateService.run_round(debate)
+        │    build prompt:
+        │      - now includes "You (the asker) said:" with all user_messages
+        │      - now includes "Questions directed at you:" from last round
+        │    each elder replies
+        │    ├─ ConvergencePolicy strips CONVERGED
+        │    └─ QuestionParser strips QUESTIONS block → Turn.questions
+        │
+        ▼
+  Bus → pane renders elder's cleaned answer + its own questions
+        (asker's pane) + incoming questions in target pane
+```
+
+## Persistence
+
+`JsonFileStore` serialiser/deserialiser extended:
+
+```json
+{
+  "id": "...",
+  "prompt": "...",
+  "pack": {...},
+  "rounds": [
+    {
+      "number": 1,
+      "turns": [
+        {
+          "elder": "claude",
+          "answer": {...},
+          "questions": [
+            {"from_elder": "claude", "to_elder": "gemini",
+             "text": "...", "round_number": 1}
+          ]
+        }
+      ]
+    }
+  ],
+  "status": "in_progress",
+  "synthesis": null,
+  "user_messages": [
+    {"text": "...", "after_round": 1, "created_at": "2026-04-19T..."}
+  ]
+}
+```
+
+Existing saved debates without `user_messages` / `questions` keys are read with `.get(..., [])` / `.get(..., ())` defaults so pre-v3 debates still load.
+
+## Error handling
+
+- User submits an empty message (whitespace only): silently ignored; TextArea clears.
+- User submits while a round is still in flight: can't — TextArea is disabled. No queueing.
+- Elder emits a malformed `QUESTIONS:` block (e.g. missing `@`): parser tolerates and returns `()`, no error. The raw text stays in the answer (including the broken `QUESTIONS:` line). Graceful degradation.
+- Elder emits `@unknown_elder`: ignored. Only `@claude` / `@gemini` / `@chatgpt` match.
+- Elder emits a `@self` question (`@claude` from Claude): dropped silently. Avoids weird self-directed prompts.
+
+Domain services still never raise for adapter failures — unchanged contract.
+
+## Testing strategy
+
+| Layer | What | Test file |
+|---|---|---|
+| Unit | `UserMessage`, `ElderQuestion` dataclass construction + equality | `tests/unit/test_models.py` (add cases) |
+| Unit | `QuestionParser.parse` — well-formed block, missing header, unknown elder, self-directed, trailing whitespace, no block | `tests/unit/test_question_parser.py` |
+| Unit | `PromptBuilder` — "You said" section present when user_messages populated, "Questions directed at you" present when target had questions last round, sections omitted when empty | `tests/unit/test_prompting.py` (extend) |
+| Unit | `DebateService.add_user_message` appends, saves, publishes, returns the message with the right `after_round` | `tests/unit/test_debate_service.py` (extend) |
+| Unit | `DebateService.run_round` populates `Turn.questions` from the reply | `tests/unit/test_debate_service.py` (extend) |
+| Unit | `JsonFileStore` round-trips `user_messages` and per-turn `questions` | `tests/unit/test_json_file_store.py` (extend) |
+| E2E | TUI: user types a message between rounds → appears in all three elder panes; next round prompt includes it | `tests/e2e/test_tui_user_messages.py` |
+| E2E | TUI: elder emits a `QUESTIONS: @gemini ...` block → question appears in Claude's pane as `[To Gemini]` and Gemini's pane as `[From Claude]`; Gemini's round 2 prompt includes "Questions directed at you" | `tests/e2e/test_tui_elder_questions.py` |
+| Edited E2E | Existing full-debate e2e — change `Input` references to `TextArea`, `pilot.press` becomes `pilot.press(..., "ctrl+enter")` | `tests/e2e/test_tui_full_debate.py` |
+
+## What's explicitly out of scope
+
+- User can't edit or delete a sent message. (If important, defer to v4.)
+- User can't target a specific elder (e.g., "@claude only"). All user messages are moderator-level, shown to all three.
+- Elders can't ask questions of the *user* (one-way only: users→elders and elders→elders). If they want clarification, they can use dissent or flag it in their answer text.
+- No hotkey to "ask for a user response" — elders have no way to pause and demand input.
+- Synthesis prompt ignores elder questions. The synthesiser sees the full history as today; the tension captured by questions is embedded in the answers themselves.
+
+## Open questions deferred to implementation
+
+- Textual's `TextArea` submit API: does it natively support `ctrl+enter` via `bindings`, or do we need a custom `on_key` handler? Verify at implementation time.
+- Should the "Anything to add?" placeholder change as the debate progresses (e.g. to "Clarify further, or press c for another round")? Start simple, adjust if it feels stale.

--- a/tests/e2e/test_elder_pane_widget.py
+++ b/tests/e2e/test_elder_pane_widget.py
@@ -172,13 +172,8 @@ async def test_widget_renders_asker_question_in_asker_pane():
     async with _Host(widget).run_test() as pilot:
         await pilot.pause()
         widget.begin_thinking(1)
-        q = ElderQuestion(
-            from_elder="claude", to_elder="gemini",
-            text="timeline?", round_number=1
-        )
-        widget.end_thinking_completed(
-            _answer(text="My answer"), questions=(q,)
-        )
+        q = ElderQuestion(from_elder="claude", to_elder="gemini", text="timeline?", round_number=1)
+        widget.end_thinking_completed(_answer(text="My answer"), questions=(q,))
         await pilot.pause()
         history = widget.history_text()
         assert "My answer" in history
@@ -197,10 +192,7 @@ async def test_widget_renders_incoming_question_in_target_pane():
     )
     async with _Host(widget).run_test() as pilot:
         await pilot.pause()
-        q = ElderQuestion(
-            from_elder="claude", to_elder="gemini",
-            text="timeline?", round_number=1
-        )
+        q = ElderQuestion(from_elder="claude", to_elder="gemini", text="timeline?", round_number=1)
         widget.on_incoming_question(q)
         await pilot.pause()
         history = widget.history_text()

--- a/tests/e2e/test_elder_pane_widget.py
+++ b/tests/e2e/test_elder_pane_widget.py
@@ -8,7 +8,7 @@ from textual.app import App, ComposeResult
 from council.adapters.clock.fake import FakeClock
 from council.app.tui.elder_pane import ElderPaneWidget
 from council.app.tui.verbs import FixedVerbChooser
-from council.domain.models import ElderAnswer, ElderError
+from council.domain.models import ElderAnswer, ElderError, ElderQuestion, UserMessage
 
 
 def _answer(elder="claude", text="hi", agreed=True):
@@ -131,3 +131,78 @@ async def test_synthesis_widget_hides_history_divider_and_placeholder():
         assert "The final synthesised answer." in history
         # Synthesis doesn't have round dividers.
         assert "Round 2" not in history
+
+
+async def test_widget_renders_user_message_inline():
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="claude",
+        display_name="Claude",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        widget.begin_thinking(1)
+        widget.end_thinking_completed(_answer(text="R1 answer"))
+        await pilot.pause()
+        widget.on_user_message(
+            UserMessage(
+                text="please clarify scope",
+                after_round=1,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            )
+        )
+        await pilot.pause()
+        history = widget.history_text()
+        assert "R1 answer" in history
+        assert "please clarify scope" in history
+        assert "You" in history
+
+
+async def test_widget_renders_asker_question_in_asker_pane():
+    """Claude's pane shows Claude's own outgoing questions as '[To Gemini] …'."""
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="claude",
+        display_name="Claude",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        widget.begin_thinking(1)
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini",
+            text="timeline?", round_number=1
+        )
+        widget.end_thinking_completed(
+            _answer(text="My answer"), questions=(q,)
+        )
+        await pilot.pause()
+        history = widget.history_text()
+        assert "My answer" in history
+        assert "To Gemini" in history
+        assert "timeline?" in history
+
+
+async def test_widget_renders_incoming_question_in_target_pane():
+    """Gemini's pane shows Claude's question TO Gemini as '[From Claude] …'."""
+    clock = FakeClock(now=datetime(2026, 4, 19, 12, tzinfo=timezone.utc))
+    widget = ElderPaneWidget(
+        elder_id="gemini",
+        display_name="Gemini",
+        verb_chooser=FixedVerbChooser("Pondering"),
+        clock=clock,
+    )
+    async with _Host(widget).run_test() as pilot:
+        await pilot.pause()
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini",
+            text="timeline?", round_number=1
+        )
+        widget.on_incoming_question(q)
+        await pilot.pause()
+        history = widget.history_text()
+        assert "From Claude" in history
+        assert "timeline?" in history

--- a/tests/e2e/test_tui_elder_questions.py
+++ b/tests/e2e/test_tui_elder_questions.py
@@ -1,0 +1,58 @@
+import asyncio
+from datetime import datetime, timezone
+
+from council.adapters.clock.fake import FakeClock
+from council.adapters.elders.fake import FakeElder
+from council.adapters.packs.filesystem import FilesystemPackLoader
+from council.adapters.storage.in_memory import InMemoryStore
+from council.app.tui.app import CouncilApp
+from tests.e2e.conftest import pane_lines
+
+
+async def _wait_until(pilot, predicate, *, timeout_s=5.0, tick=0.05):
+    elapsed = 0.0
+    while not predicate():
+        await pilot.pause()
+        await asyncio.sleep(tick)
+        elapsed += tick
+        if elapsed > timeout_s:
+            raise AssertionError(f"Timed out; elapsed={elapsed:.2f}s")
+
+
+async def test_elder_question_surfaces_in_both_asker_and_target_panes(tmp_path):
+    (tmp_path / "bare").mkdir()
+    elders = {
+        "claude": FakeElder(
+            elder_id="claude",
+            replies=[
+                "My answer.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
+            ],
+        ),
+        "gemini": FakeElder(elder_id="gemini", replies=["mine\nCONVERGED: no"]),
+        "chatgpt": FakeElder(elder_id="chatgpt", replies=["mine\nCONVERGED: no"]),
+    }
+    app = CouncilApp(
+        elders=elders,
+        store=InMemoryStore(),
+        clock=FakeClock(now=datetime(2026, 4, 19, tzinfo=timezone.utc)),
+        pack_loader=FilesystemPackLoader(root=tmp_path),
+        pack_name="bare",
+    )
+    async with app.run_test() as pilot:
+        await pilot.press(*"Go")
+        await pilot.press("ctrl+enter")
+        await _wait_until(pilot, lambda: app.awaiting_decision)
+
+        # Claude's pane should show the outgoing question.
+        claude_text = pane_lines(app, "claude")
+        assert "To Gemini" in claude_text
+        assert "Timeline?" in claude_text
+
+        # Gemini's pane should show the incoming question.
+        gemini_text = pane_lines(app, "gemini")
+        assert "From Claude" in gemini_text
+        assert "Timeline?" in gemini_text
+
+        # ChatGPT's pane should NOT show this question (not directed at it).
+        chatgpt_text = pane_lines(app, "chatgpt")
+        assert "Timeline?" not in chatgpt_text

--- a/tests/e2e/test_tui_elder_questions.py
+++ b/tests/e2e/test_tui_elder_questions.py
@@ -24,9 +24,7 @@ async def test_elder_question_surfaces_in_both_asker_and_target_panes(tmp_path):
     elders = {
         "claude": FakeElder(
             elder_id="claude",
-            replies=[
-                "My answer.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
-            ],
+            replies=["My answer.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"],
         ),
         "gemini": FakeElder(elder_id="gemini", replies=["mine\nCONVERGED: no"]),
         "chatgpt": FakeElder(elder_id="chatgpt", replies=["mine\nCONVERGED: no"]),

--- a/tests/e2e/test_tui_full_debate.py
+++ b/tests/e2e/test_tui_full_debate.py
@@ -44,7 +44,7 @@ async def test_full_debate_via_tui(tmp_path):
 
     async with app.run_test() as pilot:
         await pilot.press(*"What should I do?")
-        await pilot.press("enter")
+        await pilot.press("ctrl+enter")
         await _wait_until(pilot, lambda: app.awaiting_decision)
 
         await pilot.press("s")

--- a/tests/e2e/test_tui_health_check_gate.py
+++ b/tests/e2e/test_tui_health_check_gate.py
@@ -68,7 +68,7 @@ async def test_unhealthy_elder_produces_warning_line(tmp_path):
 
 
 async def test_all_unhealthy_disables_input(tmp_path):
-    from textual.widgets import Input
+    from council.app.tui.app import CouncilInput
 
     app = _app(
         tmp_path,
@@ -81,7 +81,7 @@ async def test_all_unhealthy_disables_input(tmp_path):
     async with app.run_test() as pilot:
         await _wait_until(
             pilot,
-            lambda: app.query_one("#input", Input).disabled,
+            lambda: app.query_one("#input", CouncilInput).disabled,
         )
         transcript = "\n".join(app.rendered_lines)
         assert "No elders available" in transcript

--- a/tests/e2e/test_tui_history_per_elder.py
+++ b/tests/e2e/test_tui_history_per_elder.py
@@ -44,7 +44,7 @@ async def test_two_rounds_appear_in_each_elder_pane_with_divider(tmp_path):
     )
     async with app.run_test(size=(80, 40)) as pilot:
         await pilot.press(*"Two rounds?")
-        await pilot.press("enter")
+        await pilot.press("ctrl+enter")
         await _wait_until(pilot, lambda: app.awaiting_decision)
         # First round landed.  action_continue_round sets awaiting_decision=False
         # before spawning round 2; the bus consumer flips it back to True

--- a/tests/e2e/test_tui_tab_navigation.py
+++ b/tests/e2e/test_tui_tab_navigation.py
@@ -38,7 +38,7 @@ async def test_number_key_focuses_correct_pane(tmp_path):
     app = _app(tmp_path)
     async with app.run_test(size=(80, 40)) as pilot:  # narrow → tabs
         await pilot.press(*"Any question")
-        await pilot.press("enter")
+        await pilot.press("ctrl+enter")
         await _wait_until(pilot, lambda: app.awaiting_decision)
 
         for key, elder in [("2", "gemini"), ("3", "chatgpt"), ("4", "synthesis"), ("1", "claude")]:

--- a/tests/e2e/test_tui_user_messages.py
+++ b/tests/e2e/test_tui_user_messages.py
@@ -1,0 +1,60 @@
+import asyncio
+from datetime import datetime, timezone
+
+from council.adapters.clock.fake import FakeClock
+from council.adapters.elders.fake import FakeElder
+from council.adapters.packs.filesystem import FilesystemPackLoader
+from council.adapters.storage.in_memory import InMemoryStore
+from council.app.tui.app import CouncilApp
+from tests.e2e.conftest import pane_lines
+
+
+async def _wait_until(pilot, predicate, *, timeout_s=5.0, tick=0.05):
+    elapsed = 0.0
+    while not predicate():
+        await pilot.pause()
+        await asyncio.sleep(tick)
+        elapsed += tick
+        if elapsed > timeout_s:
+            raise AssertionError(f"Timed out; elapsed={elapsed:.2f}s")
+
+
+async def test_user_message_appears_in_all_elder_panes(tmp_path):
+    (tmp_path / "bare").mkdir()
+    elders = {
+        "claude": FakeElder(
+            elder_id="claude",
+            replies=["R1 c\nCONVERGED: no", "R2 c\nCONVERGED: yes"],
+        ),
+        "gemini": FakeElder(
+            elder_id="gemini",
+            replies=["R1 g\nCONVERGED: no", "R2 g\nCONVERGED: yes"],
+        ),
+        "chatgpt": FakeElder(
+            elder_id="chatgpt",
+            replies=["R1 x\nCONVERGED: no", "R2 x\nCONVERGED: yes"],
+        ),
+    }
+    app = CouncilApp(
+        elders=elders,
+        store=InMemoryStore(),
+        clock=FakeClock(now=datetime(2026, 4, 19, tzinfo=timezone.utc)),
+        pack_loader=FilesystemPackLoader(root=tmp_path),
+        pack_name="bare",
+    )
+    async with app.run_test() as pilot:
+        await pilot.press(*"Initial question")
+        await pilot.press("ctrl+enter")
+        await _wait_until(pilot, lambda: app.awaiting_decision)
+
+        # Type a user message and submit.
+        # Input is re-enabled at awaiting_decision; focus it first.
+        app.query_one("#input").focus()
+        await pilot.press(*"please focus on timeline")
+        await pilot.press("ctrl+enter")
+        await pilot.pause()
+
+        for elder in ("claude", "gemini", "chatgpt"):
+            text = pane_lines(app, elder)
+            assert "please focus on timeline" in text
+            assert "You after round 1" in text

--- a/tests/unit/test_debate_service.py
+++ b/tests/unit/test_debate_service.py
@@ -177,3 +177,69 @@ class TestSynthesize:
         d = _fresh_debate()
         await s.run_round(d)
         assert store.load("d1") is d
+
+
+from council.domain.events import UserMessageReceived
+
+
+class TestAddUserMessage:
+    async def test_appends_saves_and_publishes(self, svc):
+        s, _ = svc
+        d = _fresh_debate()
+        # Run a round so user_messages.after_round = 1 makes sense
+        await s.run_round(d)
+        collected: list = []
+
+        async def collect():
+            async for ev in s.bus.subscribe():
+                collected.append(ev)
+
+        import asyncio
+        task = asyncio.create_task(collect())
+        await asyncio.sleep(0)
+        msg = await s.add_user_message(d, "please focus on timeline")
+        await asyncio.sleep(0)
+        task.cancel()
+        assert msg.text == "please focus on timeline"
+        assert msg.after_round == 1
+        assert d.user_messages == [msg]
+        assert any(
+            isinstance(ev, UserMessageReceived) and ev.message is msg
+            for ev in collected
+        )
+
+    async def test_strips_whitespace(self, svc):
+        s, _ = svc
+        d = _fresh_debate()
+        msg = await s.add_user_message(d, "   with space  \n")
+        assert msg.text == "with space"
+
+
+class TestRunRoundExtractsQuestions:
+    async def test_questions_block_becomes_turn_questions(self, clock):
+        elders = {
+            "claude": FakeElder(
+                elder_id="claude",
+                replies=[
+                    "My reply.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
+                ],
+            ),
+            "gemini": FakeElder(
+                elder_id="gemini",
+                replies=["Mine\nCONVERGED: yes"],
+            ),
+            "chatgpt": FakeElder(
+                elder_id="chatgpt",
+                replies=["Mine\nCONVERGED: yes"],
+            ),
+        }
+        s = DebateService(
+            elders=elders, store=InMemoryStore(), clock=clock, bus=InMemoryBus()
+        )
+        d = _fresh_debate()
+        r = await s.run_round(d)
+        claude_turn = next(t for t in r.turns if t.elder == "claude")
+        assert len(claude_turn.questions) == 1
+        assert claude_turn.questions[0].to_elder == "gemini"
+        assert "QUESTIONS" not in (claude_turn.answer.text or "")
+        assert claude_turn.answer.text.strip() == "My reply."

--- a/tests/unit/test_debate_service.py
+++ b/tests/unit/test_debate_service.py
@@ -6,6 +6,7 @@ from council.adapters.clock.fake import FakeClock
 from council.adapters.elders.fake import FakeElder
 from council.adapters.storage.in_memory import InMemoryStore
 from council.domain.debate_service import DebateService
+from council.domain.events import UserMessageReceived
 from council.domain.models import CouncilPack, Debate
 
 
@@ -179,9 +180,6 @@ class TestSynthesize:
         assert store.load("d1") is d
 
 
-from council.domain.events import UserMessageReceived
-
-
 class TestAddUserMessage:
     async def test_appends_saves_and_publishes(self, svc):
         s, _ = svc
@@ -195,6 +193,7 @@ class TestAddUserMessage:
                 collected.append(ev)
 
         import asyncio
+
         task = asyncio.create_task(collect())
         await asyncio.sleep(0)
         msg = await s.add_user_message(d, "please focus on timeline")
@@ -203,10 +202,7 @@ class TestAddUserMessage:
         assert msg.text == "please focus on timeline"
         assert msg.after_round == 1
         assert d.user_messages == [msg]
-        assert any(
-            isinstance(ev, UserMessageReceived) and ev.message is msg
-            for ev in collected
-        )
+        assert any(isinstance(ev, UserMessageReceived) and ev.message is msg for ev in collected)
 
     async def test_strips_whitespace(self, svc):
         s, _ = svc
@@ -220,9 +216,7 @@ class TestRunRoundExtractsQuestions:
         elders = {
             "claude": FakeElder(
                 elder_id="claude",
-                replies=[
-                    "My reply.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"
-                ],
+                replies=["My reply.\n\nQUESTIONS:\n@gemini Timeline?\n\nCONVERGED: no"],
             ),
             "gemini": FakeElder(
                 elder_id="gemini",
@@ -233,9 +227,7 @@ class TestRunRoundExtractsQuestions:
                 replies=["Mine\nCONVERGED: yes"],
             ),
         }
-        s = DebateService(
-            elders=elders, store=InMemoryStore(), clock=clock, bus=InMemoryBus()
-        )
+        s = DebateService(elders=elders, store=InMemoryStore(), clock=clock, bus=InMemoryBus())
         d = _fresh_debate()
         r = await s.run_round(d)
         claude_turn = next(t for t in r.turns if t.elder == "claude")

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -68,23 +68,27 @@ def test_user_message_received_carries_message():
 
 def test_turn_completed_carries_questions_tuple():
     from council.domain.models import ElderAnswer, ElderQuestion
+
     ans = ElderAnswer(
-        elder="claude", text="x", error=None, agreed=True,
+        elder="claude",
+        text="x",
+        error=None,
+        agreed=True,
         created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
     )
-    q = ElderQuestion(
-        from_elder="claude", to_elder="gemini", text="why?", round_number=1
-    )
-    e = TurnCompleted(
-        elder="claude", round_number=1, answer=ans, questions=(q,)
-    )
+    q = ElderQuestion(from_elder="claude", to_elder="gemini", text="why?", round_number=1)
+    e = TurnCompleted(elder="claude", round_number=1, answer=ans, questions=(q,))
     assert e.questions == (q,)
 
 
 def test_turn_completed_questions_default_empty():
     from council.domain.models import ElderAnswer
+
     ans = ElderAnswer(
-        elder="claude", text="x", error=None, agreed=True,
+        elder="claude",
+        text="x",
+        error=None,
+        agreed=True,
         created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
     )
     e = TurnCompleted(elder="claude", round_number=1, answer=ans)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -64,3 +64,28 @@ def test_user_message_received_carries_message():
     )
     e = UserMessageReceived(message=m)
     assert e.message is m
+
+
+def test_turn_completed_carries_questions_tuple():
+    from council.domain.models import ElderAnswer, ElderQuestion
+    ans = ElderAnswer(
+        elder="claude", text="x", error=None, agreed=True,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    q = ElderQuestion(
+        from_elder="claude", to_elder="gemini", text="why?", round_number=1
+    )
+    e = TurnCompleted(
+        elder="claude", round_number=1, answer=ans, questions=(q,)
+    )
+    assert e.questions == (q,)
+
+
+def test_turn_completed_questions_default_empty():
+    from council.domain.models import ElderAnswer
+    ans = ElderAnswer(
+        elder="claude", text="x", error=None, agreed=True,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    e = TurnCompleted(elder="claude", round_number=1, answer=ans)
+    assert e.questions == ()

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -51,3 +51,16 @@ def test_synthesis_and_abandoned_shapes():
     )
     assert SynthesisCompleted(answer=ans).answer is ans
     assert DebateAbandoned().__class__.__name__ == "DebateAbandoned"
+
+
+def test_user_message_received_carries_message():
+    from council.domain.events import UserMessageReceived
+    from council.domain.models import UserMessage
+
+    m = UserMessage(
+        text="clarify please",
+        after_round=1,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+    e = UserMessageReceived(message=m)
+    assert e.message is m

--- a/tests/unit/test_json_file_store.py
+++ b/tests/unit/test_json_file_store.py
@@ -8,8 +8,10 @@ from council.domain.models import (
     Debate,
     ElderAnswer,
     ElderError,
+    ElderQuestion,
     Round,
     Turn,
+    UserMessage,
 )
 
 
@@ -89,3 +91,69 @@ def test_save_overwrites_existing(tmp_path: Path):
     store.save(original)
     loaded = store.load("d1")
     assert loaded.status == "abandoned"
+
+
+def test_round_trips_user_messages(tmp_path: Path):
+    store = JsonFileStore(root=tmp_path)
+    t = datetime(2026, 4, 19, tzinfo=timezone.utc)
+    d = _debate()
+    d.user_messages.append(UserMessage(text="clarify?", after_round=1, created_at=t))
+    d.user_messages.append(UserMessage(text="follow up", after_round=2, created_at=t))
+    store.save(d)
+    loaded = store.load("d1")
+    assert len(loaded.user_messages) == 2
+    assert loaded.user_messages[0].text == "clarify?"
+    assert loaded.user_messages[1].after_round == 2
+
+
+def test_round_trips_turn_questions(tmp_path: Path):
+    store = JsonFileStore(root=tmp_path)
+    t = datetime(2026, 4, 19, tzinfo=timezone.utc)
+    d = _debate()
+    q = ElderQuestion(
+        from_elder="claude", to_elder="gemini",
+        text="timeline?", round_number=1
+    )
+    d.rounds[0].turns = [
+        Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude", text="ok", error=None, agreed=True, created_at=t
+            ),
+            questions=(q,),
+        ),
+        Turn(
+            elder="gemini",
+            answer=ElderAnswer(
+                elder="gemini", text="yes", error=None, agreed=True, created_at=t
+            ),
+        ),
+        Turn(
+            elder="chatgpt",
+            answer=ElderAnswer(
+                elder="chatgpt", text="ok", error=None, agreed=True, created_at=t
+            ),
+        ),
+    ]
+    store.save(d)
+    loaded = store.load("d1")
+    claude_turn = next(
+        t_ for t_ in loaded.rounds[0].turns if t_.elder == "claude"
+    )
+    assert len(claude_turn.questions) == 1
+    assert claude_turn.questions[0].to_elder == "gemini"
+    assert claude_turn.questions[0].text == "timeline?"
+
+
+def test_load_legacy_debate_without_user_messages_key(tmp_path: Path):
+    # Simulate a pre-v3 file without the new keys.
+    path = tmp_path / "d1.json"
+    path.write_text(
+        '{"id":"d1","prompt":"?",'
+        '"pack":{"name":"b","shared_context":null,"personas":{}},'
+        '"rounds":[],"status":"in_progress","synthesis":null}',
+        encoding="utf-8",
+    )
+    store = JsonFileStore(root=tmp_path)
+    loaded = store.load("d1")
+    assert loaded.user_messages == []

--- a/tests/unit/test_json_file_store.py
+++ b/tests/unit/test_json_file_store.py
@@ -110,36 +110,25 @@ def test_round_trips_turn_questions(tmp_path: Path):
     store = JsonFileStore(root=tmp_path)
     t = datetime(2026, 4, 19, tzinfo=timezone.utc)
     d = _debate()
-    q = ElderQuestion(
-        from_elder="claude", to_elder="gemini",
-        text="timeline?", round_number=1
-    )
+    q = ElderQuestion(from_elder="claude", to_elder="gemini", text="timeline?", round_number=1)
     d.rounds[0].turns = [
         Turn(
             elder="claude",
-            answer=ElderAnswer(
-                elder="claude", text="ok", error=None, agreed=True, created_at=t
-            ),
+            answer=ElderAnswer(elder="claude", text="ok", error=None, agreed=True, created_at=t),
             questions=(q,),
         ),
         Turn(
             elder="gemini",
-            answer=ElderAnswer(
-                elder="gemini", text="yes", error=None, agreed=True, created_at=t
-            ),
+            answer=ElderAnswer(elder="gemini", text="yes", error=None, agreed=True, created_at=t),
         ),
         Turn(
             elder="chatgpt",
-            answer=ElderAnswer(
-                elder="chatgpt", text="ok", error=None, agreed=True, created_at=t
-            ),
+            answer=ElderAnswer(elder="chatgpt", text="ok", error=None, agreed=True, created_at=t),
         ),
     ]
     store.save(d)
     loaded = store.load("d1")
-    claude_turn = next(
-        t_ for t_ in loaded.rounds[0].turns if t_.elder == "claude"
-    )
+    claude_turn = next(t_ for t_ in loaded.rounds[0].turns if t_.elder == "claude")
     assert len(claude_turn.questions) == 1
     assert claude_turn.questions[0].to_elder == "gemini"
     assert claude_turn.questions[0].text == "timeline?"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,11 +1,14 @@
 from datetime import datetime, timezone
+import pytest
 from council.domain.models import (
     CouncilPack,
     Debate,
     ElderAnswer,
     ElderError,
+    ElderQuestion,
     Round,
     Turn,
+    UserMessage,
 )
 
 
@@ -98,3 +101,88 @@ class TestDebate:
         )
         assert d.rounds == []
         assert d.status == "in_progress"
+
+
+class TestUserMessage:
+    def test_construct_with_expected_fields(self):
+        m = UserMessage(
+            text="clarify scope please",
+            after_round=1,
+            created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
+        assert m.text == "clarify scope please"
+        assert m.after_round == 1
+
+    def test_is_frozen(self):
+        m = UserMessage(
+            text="x",
+            after_round=0,
+            created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
+        with pytest.raises(Exception):
+            m.text = "y"  # type: ignore[misc]
+
+
+class TestElderQuestion:
+    def test_construct_with_expected_fields(self):
+        q = ElderQuestion(
+            from_elder="claude",
+            to_elder="gemini",
+            text="Have you considered X?",
+            round_number=1,
+        )
+        assert q.from_elder == "claude"
+        assert q.to_elder == "gemini"
+
+    def test_is_frozen(self):
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini", text="x", round_number=1
+        )
+        with pytest.raises(Exception):
+            q.text = "y"  # type: ignore[misc]
+
+
+class TestDebateUserMessages:
+    def test_fresh_debate_has_empty_user_messages(self):
+        pack = CouncilPack(name="bare", shared_context=None, personas={})
+        d = Debate(
+            id="d1",
+            prompt="?",
+            pack=pack,
+            rounds=[],
+            status="in_progress",
+            synthesis=None,
+        )
+        assert d.user_messages == []
+
+
+class TestTurnQuestions:
+    def test_fresh_turn_has_empty_questions(self):
+        t = Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude",
+                text="hi",
+                error=None,
+                agreed=True,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            ),
+        )
+        assert t.questions == ()
+
+    def test_turn_with_questions(self):
+        q = ElderQuestion(
+            from_elder="claude", to_elder="gemini", text="?", round_number=1
+        )
+        t = Turn(
+            elder="claude",
+            answer=ElderAnswer(
+                elder="claude",
+                text="hi",
+                error=None,
+                agreed=True,
+                created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+            ),
+            questions=(q,),
+        )
+        assert len(t.questions) == 1

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -135,9 +135,7 @@ class TestElderQuestion:
         assert q.to_elder == "gemini"
 
     def test_is_frozen(self):
-        q = ElderQuestion(
-            from_elder="claude", to_elder="gemini", text="x", round_number=1
-        )
+        q = ElderQuestion(from_elder="claude", to_elder="gemini", text="x", round_number=1)
         with pytest.raises(Exception):
             q.text = "y"  # type: ignore[misc]
 
@@ -171,9 +169,7 @@ class TestTurnQuestions:
         assert t.questions == ()
 
     def test_turn_with_questions(self):
-        q = ElderQuestion(
-            from_elder="claude", to_elder="gemini", text="?", round_number=1
-        )
+        q = ElderQuestion(from_elder="claude", to_elder="gemini", text="?", round_number=1)
         t = Turn(
             elder="claude",
             answer=ElderAnswer(

--- a/tests/unit/test_prompting.py
+++ b/tests/unit/test_prompting.py
@@ -1,6 +1,14 @@
 from datetime import datetime, timezone
 import pytest
-from council.domain.models import CouncilPack, Debate, ElderAnswer, ElderQuestion, Round, Turn, UserMessage
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    ElderQuestion,
+    Round,
+    Turn,
+    UserMessage,
+)
 from council.domain.prompting import PromptBuilder
 
 
@@ -219,8 +227,7 @@ class TestDirectedQuestionsInPrompt:
                 Turn(
                     elder="claude",
                     answer=_answer("claude", "t1"),
-                    questions=(_q(from_elder="claude", to_elder="gemini",
-                                  text="timeline?"),),
+                    questions=(_q(from_elder="claude", to_elder="gemini", text="timeline?"),),
                 ),
                 Turn(elder="gemini", answer=_answer("gemini", "t2")),
                 Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
@@ -239,8 +246,7 @@ class TestDirectedQuestionsInPrompt:
                 Turn(
                     elder="claude",
                     answer=_answer("claude", "t1"),
-                    questions=(_q(from_elder="claude", to_elder="chatgpt",
-                                  text="growth?"),),
+                    questions=(_q(from_elder="claude", to_elder="chatgpt", text="growth?"),),
                 ),
                 Turn(elder="gemini", answer=_answer("gemini", "t2")),
                 Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
@@ -266,8 +272,9 @@ class TestDirectedQuestionsInPrompt:
                 Turn(
                     elder="claude",
                     answer=_answer("claude", "t1"),
-                    questions=(_q(from_elder="claude", to_elder="gemini",
-                                  text="ignored in synth"),),
+                    questions=(
+                        _q(from_elder="claude", to_elder="gemini", text="ignored in synth"),
+                    ),
                 ),
                 Turn(elder="gemini", answer=_answer("gemini", "t2")),
                 Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),

--- a/tests/unit/test_prompting.py
+++ b/tests/unit/test_prompting.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import pytest
-from council.domain.models import CouncilPack, Debate, ElderAnswer, Round, Turn
+from council.domain.models import CouncilPack, Debate, ElderAnswer, ElderQuestion, Round, Turn, UserMessage
 from council.domain.prompting import PromptBuilder
 
 
@@ -142,3 +142,140 @@ class TestSynthesis:
         r1 = Round(number=1, turns=[])
         prompt = builder.build_synthesis(_debate(rounds=[r1]), by="claude")
         assert "CONVERGED" not in prompt
+
+
+def _user_msg(text="clarify", after_round=1):
+    return UserMessage(
+        text=text,
+        after_round=after_round,
+        created_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+    )
+
+
+def _q(from_elder="claude", to_elder="gemini", text="why?", round_number=1):
+    return ElderQuestion(
+        from_elder=from_elder,
+        to_elder=to_elder,
+        text=text,
+        round_number=round_number,
+    )
+
+
+class TestUserMessagesInPrompt:
+    def test_round_1_omits_user_messages_section(self, builder):
+        d = _debate()
+        d.user_messages.append(_user_msg())
+        prompt = builder.build(d, "claude", 1)
+        assert "You (the asker) said" not in prompt
+
+    def test_round_2_includes_user_messages_section(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "t1")),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        d.user_messages.append(_user_msg("focus on timeline", after_round=1))
+        prompt = builder.build(d, "claude", 2)
+        assert "You (the asker) said" in prompt
+        assert "focus on timeline" in prompt
+        assert "After round 1" in prompt
+
+    def test_round_3_shows_all_prior_user_messages_in_order(self, builder):
+        r1 = Round(
+            number=1,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "t1")),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        r2 = Round(
+            number=2,
+            turns=[
+                Turn(elder="claude", answer=_answer("claude", "u1")),
+                Turn(elder="gemini", answer=_answer("gemini", "u2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "u3")),
+            ],
+        )
+        d = _debate(rounds=[r1, r2])
+        d.user_messages.append(_user_msg("first clarification", after_round=1))
+        d.user_messages.append(_user_msg("second clarification", after_round=2))
+        prompt = builder.build(d, "claude", 3)
+        first = prompt.find("first clarification")
+        second = prompt.find("second clarification")
+        assert first != -1 and second != -1
+        assert first < second
+
+
+class TestDirectedQuestionsInPrompt:
+    def test_questions_directed_at_target_elder_are_surfaced(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="gemini",
+                                  text="timeline?"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        gemini_prompt = builder.build(d, "gemini", 2)
+        assert "Questions directed at you" in gemini_prompt
+        assert "From Claude" in gemini_prompt
+        assert "timeline?" in gemini_prompt
+
+    def test_other_questions_between_advisors_are_listed_separately(self, builder):
+        prev = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="chatgpt",
+                                  text="growth?"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[prev])
+        gemini_prompt = builder.build(d, "gemini", 2)
+        assert "Questions directed at you" not in gemini_prompt
+        assert "Other questions raised between advisors" in gemini_prompt
+        assert "Claude" in gemini_prompt and "ChatGPT" in gemini_prompt
+        assert "growth?" in gemini_prompt
+
+    def test_prompt_asks_for_questions_block(self, builder):
+        d = _debate()
+        prompt = builder.build(d, "claude", 1)
+        assert "QUESTIONS:" in prompt
+        assert "@" in prompt
+
+    def test_synthesis_prompt_ignores_questions_and_user_messages(self, builder):
+        r1 = Round(
+            number=1,
+            turns=[
+                Turn(
+                    elder="claude",
+                    answer=_answer("claude", "t1"),
+                    questions=(_q(from_elder="claude", to_elder="gemini",
+                                  text="ignored in synth"),),
+                ),
+                Turn(elder="gemini", answer=_answer("gemini", "t2")),
+                Turn(elder="chatgpt", answer=_answer("chatgpt", "t3")),
+            ],
+        )
+        d = _debate(rounds=[r1])
+        d.user_messages.append(_user_msg("ignored user msg"))
+        synth = builder.build_synthesis(d, by="claude")
+        assert "QUESTIONS:" not in synth
+        assert "You (the asker) said" not in synth
+        assert "Questions directed at you" not in synth

--- a/tests/unit/test_question_parser.py
+++ b/tests/unit/test_question_parser.py
@@ -1,0 +1,108 @@
+import pytest
+
+from council.domain.questions import QuestionParser
+
+
+@pytest.fixture
+def parser():
+    return QuestionParser()
+
+
+class TestNoBlock:
+    def test_no_questions_header_returns_raw_and_empty(self, parser):
+        raw = "Here is my answer with no questions."
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert cleaned == raw
+        assert qs == ()
+
+    def test_empty_input(self, parser):
+        cleaned, qs = parser.parse("", from_elder="claude", round_number=1)
+        assert cleaned == ""
+        assert qs == ()
+
+
+class TestValidBlock:
+    def test_single_question_extracted(self, parser):
+        raw = (
+            "My answer text.\n"
+            "\n"
+            "QUESTIONS:\n"
+            "@gemini Have you considered timeline?"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert "QUESTIONS:" not in cleaned
+        assert "@gemini" not in cleaned
+        assert cleaned.strip() == "My answer text."
+        assert len(qs) == 1
+        assert qs[0].from_elder == "claude"
+        assert qs[0].to_elder == "gemini"
+        assert qs[0].text == "Have you considered timeline?"
+        assert qs[0].round_number == 1
+
+    def test_multiple_questions_extracted(self, parser):
+        raw = (
+            "Answer.\n"
+            "QUESTIONS:\n"
+            "@gemini Timeline?\n"
+            "@chatgpt Growth?"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=2)
+        assert cleaned.strip() == "Answer."
+        assert len(qs) == 2
+        assert {q.to_elder for q in qs} == {"gemini", "chatgpt"}
+
+    def test_case_insensitive_header_and_elder(self, parser):
+        raw = "Answer.\nquestions:\n@GEMINI Timeline?"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+
+class TestMalformedOrUnknown:
+    def test_unknown_elder_ignored(self, parser):
+        raw = "Answer.\nQUESTIONS:\n@bob Ignore me\n@gemini Keep me"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # Unknown @bob doesn't match; @gemini on next line should still be captured
+        # because we read until a blank line or end-of-input, tolerating non-matching
+        # lines as "noise inside the block".
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+    def test_self_directed_question_dropped(self, parser):
+        raw = "Answer.\nQUESTIONS:\n@claude What about me?\n@gemini Real question?"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert qs[0].to_elder == "gemini"
+
+    def test_questions_header_without_valid_lines_yields_empty(self, parser):
+        raw = "Answer.\nQUESTIONS:\n(no valid questions)"
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # No @elder lines follow — treat as not-a-block; keep raw text.
+        assert qs == ()
+        assert cleaned == raw
+
+    def test_block_terminates_at_blank_line(self, parser):
+        raw = (
+            "Answer.\n"
+            "QUESTIONS:\n"
+            "@gemini Real question?\n"
+            "\n"
+            "@chatgpt This is after the block and should stay in body"
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        assert len(qs) == 1
+        assert "should stay in body" in cleaned
+
+
+class TestPositioning:
+    def test_only_strips_when_block_is_at_tail(self, parser):
+        raw = (
+            "QUESTIONS:\n"
+            "@gemini Early question\n"
+            "\n"
+            "But this is the real body."
+        )
+        cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
+        # The QUESTIONS block is not at the tail — keep raw, return ().
+        assert qs == ()
+        assert cleaned == raw

--- a/tests/unit/test_question_parser.py
+++ b/tests/unit/test_question_parser.py
@@ -23,12 +23,7 @@ class TestNoBlock:
 
 class TestValidBlock:
     def test_single_question_extracted(self, parser):
-        raw = (
-            "My answer text.\n"
-            "\n"
-            "QUESTIONS:\n"
-            "@gemini Have you considered timeline?"
-        )
+        raw = "My answer text.\n\nQUESTIONS:\n@gemini Have you considered timeline?"
         cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
         assert "QUESTIONS:" not in cleaned
         assert "@gemini" not in cleaned
@@ -40,12 +35,7 @@ class TestValidBlock:
         assert qs[0].round_number == 1
 
     def test_multiple_questions_extracted(self, parser):
-        raw = (
-            "Answer.\n"
-            "QUESTIONS:\n"
-            "@gemini Timeline?\n"
-            "@chatgpt Growth?"
-        )
+        raw = "Answer.\nQUESTIONS:\n@gemini Timeline?\n@chatgpt Growth?"
         cleaned, qs = parser.parse(raw, from_elder="claude", round_number=2)
         assert cleaned.strip() == "Answer."
         assert len(qs) == 2
@@ -96,12 +86,7 @@ class TestMalformedOrUnknown:
 
 class TestPositioning:
     def test_only_strips_when_block_is_at_tail(self, parser):
-        raw = (
-            "QUESTIONS:\n"
-            "@gemini Early question\n"
-            "\n"
-            "But this is the real body."
-        )
+        raw = "QUESTIONS:\n@gemini Early question\n\nBut this is the real body."
         cleaned, qs = parser.parse(raw, from_elder="claude", round_number=1)
         # The QUESTIONS block is not at the tail — keep raw, return ().
         assert qs == ()


### PR DESCRIPTION
## Summary

Two cross-cutting additions to the debate flow:

- **User-as-elder.** Between rounds, the input box is re-enabled and you can type a clarifying question or comment. Press **Ctrl+Enter** to send (plain **Enter** inserts a newline). The message is added to the debate history, fans out to every elder's pane inline, and appears in the next round's prompt as a \`You (the asker) said:\` section. Input is now a multi-line \`TextArea\` (\`CouncilInput\` subclass).
- **Elder-to-elder questions.** Elders can optionally end their reply with a structured \`QUESTIONS: @elder …\` block. A new \`QuestionParser\` (parallel to \`ConvergencePolicy\`) extracts and strips it. Outgoing questions appear as \`[To Gemini]\` in the asker's pane; incoming ones appear as \`[From Claude]\` in the target's pane. The target elder's next prompt gets a prominent \`Questions directed at you:\` section.

All additive: new \`UserMessage\` and \`ElderQuestion\` domain values, new \`UserMessageReceived\` event, \`TurnCompleted\` gains a \`questions\` tuple, \`DebateService.add_user_message\`, \`PromptBuilder\` grows three sections, \`JsonFileStore\` round-trips both new shapes with backward-compat load for pre-feature debates. Domain core still has zero imports from textual / subprocess / pathlib / adapters.

## Test plan

- [x] 181 tests passing locally (unit + e2e; 9 integration deselected per default)
- [x] User message typed between rounds appears in all three elder panes
- [x] Elder \`QUESTIONS: @gemini …\` block strips from answer, emits an \`ElderQuestion\`, shows in Claude's pane as \`[To Gemini]\`, and in Gemini's pane as \`[From Claude]\`, but not in ChatGPT's pane
- [x] PromptBuilder includes the new sections only when they have content
- [x] Synthesis prompt unchanged (no user messages, no questions, no QUESTIONS instruction)
- [x] JsonFileStore loads pre-feature debate JSON without the new keys
- [x] TextArea disabled during rounds, re-enabled on \`RoundCompleted\`
- [ ] Manual smoke with real vendor CLIs to confirm the Ctrl+Enter submit and pane rendering land as expected on a real terminal

## Docs

- Spec: \`docs/superpowers/specs/2026-04-19-interactive-debate-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-19-interactive-debate.md\`
- README updated with \"Participating in the debate\" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)