### PR TITLE
test(homogenisation): update corpus size assertion from 8 to 16

### DIFF
--- a/tests/unit/test_homogenisation_corpus.py
+++ b/tests/unit/test_homogenisation_corpus.py
@@ -26,9 +26,9 @@ def test_load_corpus_rejects_missing_fields(tmp_path: Path) -> None:
         load_corpus(path)
 
 
-def test_real_corpus_has_eight_prompts_with_unique_ids() -> None:
+def test_real_corpus_has_sixteen_prompts_with_unique_ids() -> None:
     path = Path(__file__).parents[2] / "scripts" / "homogenisation_corpus.json"
     prompts = load_corpus(path)
-    assert len(prompts) == 8
+    assert len(prompts) == 16
     ids = [p.id for p in prompts]
-    assert len(set(ids)) == 8
+    assert len(set(ids)) == 16


### PR DESCRIPTION
The corpus was expanded to 16 prompts in d03e959 but the real-corpus test still asserted the pre-expansion count of 8. Align the assertion and rename the test to match.