### PR TITLE
refactor: split headless runner and CouncilApp into focused modules

### DIFF
--- a/council/app/headless/printing.py
+++ b/council/app/headless/printing.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from council.domain.models import Debate, ElderId
+from council.domain.preference import MultiJudgeVerdict, PreferenceVerdict
+from council.domain.synthesis_output import SynthesisOutput
+
+_LABELS: dict[ElderId, str] = {
+    "ada": "Ada",
+    "kai": "Kai",
+    "mei": "Mei",
+}
+
+
+def label(elder: ElderId) -> str:
+    return _LABELS[elder]
+
+
+def print_rounds(debate: Debate) -> None:
+    for rnd in debate.rounds:
+        print(f"--- Round {rnd.number} ---")
+        for turn in rnd.turns:
+            name = _LABELS[turn.elder]
+            if turn.answer.error:
+                print(f"[{name}] ERROR {turn.answer.error.kind}: {turn.answer.error.detail}\n")
+            else:
+                print(f"[{name}] {turn.answer.text}\n")
+
+
+def print_best_r1_pick(elder: ElderId, reason: str) -> None:
+    print(f"\n[Best R1 (judge-picked): {_LABELS[elder]}] {reason}\n")
+
+
+def print_best_r1_unavailable() -> None:
+    print("\n[Best-R1 baseline unavailable (no OpenRouter judge configured).]\n")
+
+
+def print_synthesis(
+    *,
+    structured: SynthesisOutput,
+    synthesizer: ElderId,
+    risk_note: str | None,
+) -> None:
+    print(f"\n[Synthesis by {_LABELS[synthesizer]}]\n")
+    if risk_note:
+        print(f"{risk_note}\n")
+    print(structured.answer)
+    if structured.why:
+        print(f"\nWhy: {structured.why}")
+    if structured.disagreements:
+        print("\nDisagreements:")
+        for d in structured.disagreements:
+            print(f"- {d}")
+    else:
+        print("\nDisagreements: none material.")
+
+
+def print_preference(preference: PreferenceVerdict | MultiJudgeVerdict) -> None:
+    if isinstance(preference, MultiJudgeVerdict):
+        print(
+            f"\n[Preference judges] aggregate={preference.aggregate} "
+            f"(unanimous={preference.unanimous}, "
+            f"n_judges={len(preference.verdicts)})"
+        )
+        for jv in preference.verdicts:
+            print(f"  · {jv.judge_model}: {jv.verdict.winner} — {jv.verdict.reason}")
+    else:
+        print(f"\n[Preference judge] {preference.winner} — {preference.reason}")
+
+
+def print_report(report_md: str, *, saved_to: Path | None) -> None:
+    print("\n--- Debate report ---\n")
+    print(report_md)
+    if saved_to is not None:
+        print(f"\nReport saved to {saved_to}")
+
+
+def print_best_r1_only_deliverable(debate: Debate, best_r1_text: str | None) -> None:
+    if debate.best_r1_elder is not None and best_r1_text:
+        print(f"[Answer (best-R1, {_LABELS[debate.best_r1_elder]})] {best_r1_text}")
+    else:
+        print("[warning] best-R1-only mode but no judge available — no deliverable produced.")
+
+
+def print_run_summary_path(path: Path) -> None:
+    print(f"\n[run summary] {path}")
+
+
+def print_policy_warning(warning: str) -> None:
+    print(f"[warning] {warning}")
+
+
+def print_max_rounds_exhausted(max_rounds: int) -> None:
+    print(
+        f"[warning] Hit policy max_rounds={max_rounds} "
+        "without full convergence. Synthesising best-effort."
+    )
+
+
+def print_report_failed(error: Exception) -> None:
+    print(f"\n[warning] Report generation failed: {error}")

--- a/council/app/headless/reporting.py
+++ b/council/app/headless/reporting.py
@@ -98,9 +98,7 @@ async def generate_and_save_report(
     report_store,  # ReportFileStore | None
 ) -> None:
     try:
-        report_md = await svc.generate_report(
-            debate, by=synthesizer, synthesis_risk_note=risk_note
-        )
+        report_md = await svc.generate_report(debate, by=synthesizer, synthesis_risk_note=risk_note)
     except Exception as ex:
         print_report_failed(ex)
         return

--- a/council/app/headless/reporting.py
+++ b/council/app/headless/reporting.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from council.app.headless.printing import (
+    print_report,
+    print_report_failed,
+    print_run_summary_path,
+)
+from council.domain.debate_policy import DebatePolicy
+from council.domain.debate_service import DebateService
+from council.domain.diversity import DiversityScore, score_roster
+from council.domain.models import Debate, ElderId
+from council.domain.ports import ElderPort
+from council.domain.preference import (
+    MultiJudgeVerdict,
+    PreferenceVerdict,
+    judge_preference,
+    judge_preference_multi,
+)
+from council.domain.roster import RosterSpec
+from council.domain.run_summary import build_run_summary, write_run_summary
+from council.domain.synthesis_output import SynthesisOutput, parse_synthesis
+
+
+def synthesis_risk_note(
+    *,
+    policy: DebatePolicy,
+    roster_spec: RosterSpec | None,
+) -> str | None:
+    """Surface the "synthesis rarely wins on low/medium diversity" warning.
+
+    Rationale: under the 2026-04-19 probe and its 2026-04-20 judge-swap
+    replication, synthesis rarely beat the strongest individual R1 answer
+    on low/medium-diversity rosters. We surface this so users compare
+    outputs rather than trusting synthesis blindly. High-diversity: omit
+    (evidence is ambiguous). No roster_spec: omit (we don't know).
+    """
+    if not policy.synthesise or roster_spec is None or not roster_spec.models:
+        return None
+    div = score_roster(roster_spec)
+    if div.classification in ("low", "medium"):
+        return (
+            f"[note] In {div.classification}-diversity runs, synthesis "
+            "historically rarely outperforms the strongest individual "
+            "answer. Both are shown — inspect both before acting."
+        )
+    return None
+
+
+async def run_synthesis(
+    *,
+    svc: DebateService,
+    debate: Debate,
+    synthesizer: ElderId,
+) -> SynthesisOutput:
+    synth = await svc.synthesize(debate, by=synthesizer)
+    return parse_synthesis(synth.text or "")
+
+
+async def judge_preference_verdict(
+    *,
+    prompt: str,
+    synthesis_answer: str,
+    best_r1_text: str,
+    preference_judge: ElderPort | None,
+    preference_judges: list[tuple[str, ElderPort]] | None,
+) -> PreferenceVerdict | MultiJudgeVerdict | None:
+    """Resolve synthesis-vs-best-R1 preference.
+
+    Multi-judge is preferred: 2026-04-20 showed single-judge preference
+    verdicts can be judge-family biased. ``preference_judges`` takes
+    precedence over the legacy single ``preference_judge`` kwarg.
+    """
+    if preference_judges:
+        return await judge_preference_multi(
+            question=prompt,
+            synthesis=synthesis_answer,
+            best_r1=best_r1_text,
+            judges=preference_judges,
+        )
+    if preference_judge is not None:
+        return await judge_preference(
+            question=prompt,
+            synthesis=synthesis_answer,
+            best_r1=best_r1_text,
+            judge_port=preference_judge,
+        )
+    return None
+
+
+async def generate_and_save_report(
+    *,
+    svc: DebateService,
+    debate: Debate,
+    synthesizer: ElderId,
+    risk_note: str | None,
+    report_store,  # ReportFileStore | None
+) -> None:
+    try:
+        report_md = await svc.generate_report(
+            debate, by=synthesizer, synthesis_risk_note=risk_note
+        )
+    except Exception as ex:
+        print_report_failed(ex)
+        return
+    saved_to: Path | None = None
+    if report_store is not None:
+        saved_to = report_store.save(debate_id=debate.id, markdown=report_md)
+    print_report(report_md, saved_to=saved_to)
+
+
+def write_summary_sidecar(
+    *,
+    debate: Debate,
+    roster_spec: RosterSpec | None,
+    policy: DebatePolicy,
+    structured: SynthesisOutput | None,
+    preference: PreferenceVerdict | MultiJudgeVerdict | None,
+    preference_judge: ElderPort | None,
+    root: Path,
+) -> None:
+    diversity: DiversityScore | None = (
+        score_roster(roster_spec) if roster_spec is not None and roster_spec.models else None
+    )
+    # Record single-judge model id so single-verdict preference payloads
+    # carry judge provenance. Multi-judge payloads already embed the
+    # model ids inside their verdicts list.
+    preference_judge_model: str | None = None
+    if isinstance(preference, PreferenceVerdict) and preference_judge is not None:
+        preference_judge_model = getattr(preference_judge, "model", None)
+    summary = build_run_summary(
+        debate=debate,
+        roster_spec=roster_spec,
+        diversity=diversity,
+        policy=policy,
+        synthesis=structured,
+        preference=preference,
+        preference_judge_model=preference_judge_model,
+    )
+    path = write_run_summary(summary, root=root)
+    print_run_summary_path(path)
+
+
+async def emit_openrouter_cost_notice(elders: dict[ElderId, ElderPort]) -> None:
+    from council.adapters.elders.openrouter import OpenRouterAdapter, format_cost_notice
+
+    any_or = next(
+        (e for e in elders.values() if isinstance(e, OpenRouterAdapter)),
+        None,
+    )
+    used, limit = (0.0, None)
+    if any_or is not None:
+        used, limit = await any_or.fetch_credits()
+    total = sum(e.session_cost_usd for e in elders.values() if isinstance(e, OpenRouterAdapter))
+    line = format_cost_notice(
+        elders=elders,
+        # Headless is a one-shot session — the "round delta" is the whole session.
+        round_cost_delta_usd=total,
+        credits_used=used,
+        credits_limit=limit,
+    )
+    print(line)

--- a/council/app/headless/rounds.py
+++ b/council/app/headless/rounds.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from council.app.headless.printing import (
+    print_best_r1_pick,
+    print_best_r1_unavailable,
+    print_max_rounds_exhausted,
+)
+from council.domain.best_r1 import LLMJudgedBestR1Selector
+from council.domain.debate_policy import DebatePolicy, policy_for
+from council.domain.debate_service import DebateService
+from council.domain.diversity import score_roster
+from council.domain.models import Debate
+from council.domain.ports import ElderPort, TranscriptStore
+from council.domain.roster import RosterSpec
+
+
+def resolve_policy(
+    *,
+    user_override: DebatePolicy | None,
+    roster_spec: RosterSpec | None,
+    fallback_max_rounds: int,
+) -> DebatePolicy:
+    """Pick the effective policy.
+
+    Priority: explicit user override > diversity-derived default > a
+    conservative full-debate fallback (used when no roster spec is
+    available, e.g. subprocess/CLI mode where model ids are unknown).
+    """
+    if user_override is not None:
+        return user_override
+    if roster_spec is not None and roster_spec.models:
+        return policy_for(score_roster(roster_spec))
+    return DebatePolicy(
+        mode="full_debate",
+        max_rounds=fallback_max_rounds,
+        synthesise=True,
+        always_compute_best_r1=True,
+        warning=None,
+    )
+
+
+async def run_debate_rounds(
+    *,
+    debate: Debate,
+    svc: DebateService,
+    policy: DebatePolicy,
+) -> None:
+    """Execute rounds under the given policy.
+
+    R1 always runs. R2 runs for every mode except best_r1_only/r1_only.
+    full_debate then continues R3+ until convergence or max_rounds.
+    """
+    await svc.run_round(debate)
+    if policy.mode in ("best_r1_only", "r1_only"):
+        return
+
+    await svc.run_round(debate)
+    if policy.mode != "full_debate":
+        return
+
+    while len(debate.rounds) < policy.max_rounds and not svc.rules.is_converged(debate.rounds[-1]):
+        await svc.run_round(debate)
+    if len(debate.rounds) >= policy.max_rounds and not svc.rules.is_converged(debate.rounds[-1]):
+        print_max_rounds_exhausted(policy.max_rounds)
+
+
+async def select_best_r1(
+    *,
+    debate: Debate,
+    store: TranscriptStore,
+    best_r1_judge: ElderPort | None,
+) -> str | None:
+    """Judge-pick the strongest R1 answer, record it on the debate, return its text.
+
+    Subprocess mode has no cheap judge — prints a notice and skips.
+    """
+    if best_r1_judge is None:
+        print_best_r1_unavailable()
+        return None
+
+    pick = await LLMJudgedBestR1Selector(judge_port=best_r1_judge).select(debate)
+    if pick is None:
+        return None
+
+    debate.best_r1_elder = pick.elder
+    store.save(debate)
+    best_r1_text = next(
+        (t.answer.text for t in debate.rounds[0].turns if t.elder == pick.elder),
+        None,
+    )
+    print_best_r1_pick(pick.elder, pick.reason)
+    return best_r1_text

--- a/council/app/headless/runner.py
+++ b/council/app/headless/runner.py
@@ -4,123 +4,33 @@ import dataclasses
 import uuid
 from pathlib import Path
 
-from council.domain.best_r1 import LLMJudgedBestR1Selector
-from council.domain.debate_policy import DebatePolicy, policy_for
+from council.app.headless.printing import (
+    print_best_r1_only_deliverable,
+    print_policy_warning,
+    print_preference,
+    print_rounds,
+    print_synthesis,
+)
+from council.app.headless.reporting import (
+    emit_openrouter_cost_notice,
+    generate_and_save_report,
+    judge_preference_verdict,
+    run_synthesis,
+    synthesis_risk_note,
+    write_summary_sidecar,
+)
+from council.app.headless.rounds import (
+    resolve_policy,
+    run_debate_rounds,
+    select_best_r1,
+)
+from council.domain.debate_policy import DebatePolicy
 from council.domain.debate_service import DebateService
-from council.domain.diversity import DiversityScore, score_roster
 from council.domain.models import CouncilPack, Debate, ElderId
 from council.domain.ports import Clock, ElderPort, EventBus, TranscriptStore
-from council.domain.preference import (
-    MultiJudgeVerdict,
-    PreferenceVerdict,
-    judge_preference,
-    judge_preference_multi,
-)
+from council.domain.preference import MultiJudgeVerdict, PreferenceVerdict
 from council.domain.roster import RosterSpec
-from council.domain.run_summary import build_run_summary, write_run_summary
-from council.domain.synthesis_output import SynthesisOutput, parse_synthesis
-
-_LABELS: dict[ElderId, str] = {
-    "ada": "Ada",
-    "kai": "Kai",
-    "mei": "Mei",
-}
-
-
-def _resolve_policy(
-    *,
-    user_override: DebatePolicy | None,
-    roster_spec: RosterSpec | None,
-    fallback_max_rounds: int,
-) -> DebatePolicy:
-    if user_override is not None:
-        return user_override
-    if roster_spec is not None and roster_spec.models:
-        return policy_for(score_roster(roster_spec))
-    return DebatePolicy(
-        mode="full_debate",
-        max_rounds=fallback_max_rounds,
-        synthesise=True,
-        always_compute_best_r1=True,
-        warning=None,
-    )
-
-
-async def _run_debate_rounds(*, debate: Debate, svc: DebateService, policy: DebatePolicy) -> None:
-    await svc.run_round(debate)
-
-    if policy.mode in ("best_r1_only", "r1_only"):
-        return
-
-    await svc.run_round(debate)
-
-    if policy.mode != "full_debate":
-        return
-
-    while len(debate.rounds) < policy.max_rounds and not svc.rules.is_converged(debate.rounds[-1]):
-        await svc.run_round(debate)
-    if len(debate.rounds) >= policy.max_rounds and not svc.rules.is_converged(debate.rounds[-1]):
-        print(
-            f"[warning] Hit policy max_rounds={policy.max_rounds} "
-            "without full convergence. Synthesising best-effort."
-        )
-
-
-def _print_rounds(debate: Debate) -> None:
-    for rnd in debate.rounds:
-        print(f"--- Round {rnd.number} ---")
-        for turn in rnd.turns:
-            label = _LABELS[turn.elder]
-            if turn.answer.error:
-                print(f"[{label}] ERROR {turn.answer.error.kind}: {turn.answer.error.detail}\n")
-            else:
-                print(f"[{label}] {turn.answer.text}\n")
-
-
-async def _select_best_r1(
-    *,
-    debate: Debate,
-    store: TranscriptStore,
-    best_r1_judge: ElderPort | None,
-) -> str | None:
-    if best_r1_judge is None:
-        print("\n[Best-R1 baseline unavailable (no OpenRouter judge configured).]\n")
-        return None
-
-    pick = await LLMJudgedBestR1Selector(judge_port=best_r1_judge).select(debate)
-    if pick is None:
-        return None
-
-    debate.best_r1_elder = pick.elder
-    store.save(debate)
-    best_r1_text = next(
-        (t.answer.text for t in debate.rounds[0].turns if t.elder == pick.elder),
-        None,
-    )
-    print(f"\n[Best R1 (judge-picked): {_LABELS[pick.elder]}] {pick.reason}\n")
-    return best_r1_text
-
-
-def _synthesis_risk_note(
-    *,
-    policy: DebatePolicy,
-    roster_spec: RosterSpec | None,
-) -> str | None:
-    if not policy.synthesise or roster_spec is None or not roster_spec.models:
-        return None
-    # Risk disclosure rationale: under the 2026-04-19 probe and its
-    # 2026-04-20 judge-swap replication, synthesis rarely beat the
-    # strongest individual R1 answer on low/medium-diversity rosters.
-    # We surface this note so users compare outputs rather than trusting
-    # synthesis blindly in those conditions.
-    div = score_roster(roster_spec)
-    if div.classification in ("low", "medium"):
-        return (
-            f"[note] In {div.classification}-diversity runs, synthesis "
-            "historically rarely outperforms the strongest individual "
-            "answer. Both are shown — inspect both before acting."
-        )
-    return None
+from council.domain.synthesis_output import SynthesisOutput
 
 
 async def run_headless(
@@ -143,20 +53,28 @@ async def run_headless(
     run_summary_root: Path | None = None,
     synthesise_override: bool | None = None,
 ) -> None:
+    """Headless one-shot debate.
+
+    Under the adaptive policy: low-diversity rosters skip debate and
+    skip synthesis (best-R1-only); medium run R1+R2 + synthesis; high
+    run full debate + synthesis. ``max_rounds`` is only consulted as
+    the fallback when no policy and no roster_spec is supplied.
+    """
     if max_rounds < 2:
         raise ValueError("max_rounds must be at least 2 (R1+R2 are mandatory)")
 
-    effective_policy = _resolve_policy(
+    effective_policy = resolve_policy(
         user_override=policy,
         roster_spec=roster_spec,
         fallback_max_rounds=max_rounds,
     )
-
+    # --synthesise / --no-synthesise composes with the policy: e.g.
+    # full_debate --no-synthesise runs the whole debate and stops;
+    # best_r1_only --synthesise is effectively r1_only.
     if synthesise_override is not None:
         effective_policy = dataclasses.replace(effective_policy, synthesise=synthesise_override)
-
     if effective_policy.warning:
-        print(f"[warning] {effective_policy.warning}")
+        print_policy_warning(effective_policy.warning)
 
     debate = Debate(
         id=str(uuid.uuid4()),
@@ -167,9 +85,10 @@ async def run_headless(
         synthesis=None,
     )
     svc = DebateService(elders=elders, store=store, clock=clock, bus=bus)
-    await _run_debate_rounds(debate=debate, svc=svc, policy=effective_policy)
-    _print_rounds(debate)
-    best_r1_text = await _select_best_r1(
+
+    await run_debate_rounds(debate=debate, svc=svc, policy=effective_policy)
+    print_rounds(debate)
+    best_r1_text = await select_best_r1(
         debate=debate,
         store=store,
         best_r1_judge=best_r1_judge,
@@ -177,106 +96,41 @@ async def run_headless(
 
     structured: SynthesisOutput | None = None
     preference: PreferenceVerdict | MultiJudgeVerdict | None = None
-    synthesis_risk_note = _synthesis_risk_note(policy=effective_policy, roster_spec=roster_spec)
+    risk_note = synthesis_risk_note(policy=effective_policy, roster_spec=roster_spec)
 
     if effective_policy.synthesise:
-        synth = await svc.synthesize(debate, by=synthesizer)
-        structured = parse_synthesis(synth.text or "")
-        print(f"\n[Synthesis by {_LABELS[synthesizer]}]\n")
-        if synthesis_risk_note:
-            print(f"{synthesis_risk_note}\n")
-        print(structured.answer)
-        if structured.why:
-            print(f"\nWhy: {structured.why}")
-        if structured.disagreements:
-            print("\nDisagreements:")
-            for d in structured.disagreements:
-                print(f"- {d}")
-        else:
-            print("\nDisagreements: none material.")
-
+        structured = await run_synthesis(svc=svc, debate=debate, synthesizer=synthesizer)
+        print_synthesis(structured=structured, synthesizer=synthesizer, risk_note=risk_note)
         if best_r1_text and structured.answer:
-            # Preference judge(s): synthesis vs best-R1 — answers the core
-            # success-signal question. Multi-judge is preferred because
-            # 2026-04-20 showed single-judge preference verdicts can be
-            # judge-family biased.
-            if preference_judges:
-                preference = await judge_preference_multi(
-                    question=prompt,
-                    synthesis=structured.answer,
-                    best_r1=best_r1_text,
-                    judges=preference_judges,
-                )
-                print(
-                    f"\n[Preference judges] aggregate={preference.aggregate} "
-                    f"(unanimous={preference.unanimous}, "
-                    f"n_judges={len(preference.verdicts)})"
-                )
-                for jv in preference.verdicts:
-                    print(f"  · {jv.judge_model}: {jv.verdict.winner} — {jv.verdict.reason}")
-            elif preference_judge is not None:
-                preference = await judge_preference(
-                    question=prompt,
-                    synthesis=structured.answer,
-                    best_r1=best_r1_text,
-                    judge_port=preference_judge,
-                )
-                print(f"\n[Preference judge] {preference.winner} — {preference.reason}")
-
-        try:
-            report_md = await svc.generate_report(
-                debate, by=synthesizer, synthesis_risk_note=synthesis_risk_note
+            preference = await judge_preference_verdict(
+                prompt=prompt,
+                synthesis_answer=structured.answer,
+                best_r1_text=best_r1_text,
+                preference_judge=preference_judge,
+                preference_judges=preference_judges,
             )
-            print("\n--- Debate report ---\n")
-            print(report_md)
-            if report_store is not None:
-                path = report_store.save(debate_id=debate.id, markdown=report_md)
-                print(f"\nReport saved to {path}")
-        except Exception as ex:
-            print(f"\n[warning] Report generation failed: {ex}")
+            if preference is not None:
+                print_preference(preference)
+        await generate_and_save_report(
+            svc=svc,
+            debate=debate,
+            synthesizer=synthesizer,
+            risk_note=risk_note,
+            report_store=report_store,
+        )
     else:
-        if debate.best_r1_elder is not None and best_r1_text:
-            print(f"[Answer (best-R1, {_LABELS[debate.best_r1_elder]})] {best_r1_text}")
-        else:
-            print("[warning] best-R1-only mode but no judge available — no deliverable produced.")
+        print_best_r1_only_deliverable(debate, best_r1_text)
 
     if run_summary_root is not None:
-        diversity: DiversityScore | None = (
-            score_roster(roster_spec) if roster_spec is not None and roster_spec.models else None
-        )
-        preference_judge_model: str | None = None
-        if isinstance(preference, PreferenceVerdict) and preference_judge is not None:
-            preference_judge_model = getattr(preference_judge, "model", None)
-        summary = build_run_summary(
+        write_summary_sidecar(
             debate=debate,
             roster_spec=roster_spec,
-            diversity=diversity,
             policy=effective_policy,
-            synthesis=structured,
+            structured=structured,
             preference=preference,
-            preference_judge_model=preference_judge_model,
+            preference_judge=preference_judge,
+            root=run_summary_root,
         )
-        summary_path = write_run_summary(summary, root=run_summary_root)
-        print(f"\n[run summary] {summary_path}")
 
     if using_openrouter:
-        from council.adapters.elders.openrouter import (
-            OpenRouterAdapter,
-            format_cost_notice,
-        )
-
-        any_or = next(
-            (e for e in elders.values() if isinstance(e, OpenRouterAdapter)),
-            None,
-        )
-        used, limit = (0.0, None)
-        if any_or is not None:
-            used, limit = await any_or.fetch_credits()
-        total = sum(e.session_cost_usd for e in elders.values() if isinstance(e, OpenRouterAdapter))
-        line = format_cost_notice(
-            elders=elders,
-            round_cost_delta_usd=total,
-            credits_used=used,
-            credits_limit=limit,
-        )
-        print(line)
+        await emit_openrouter_cost_notice(elders)

--- a/council/app/tui/app.py
+++ b/council/app/tui/app.py
@@ -11,7 +11,11 @@ from textual.binding import Binding
 from textual.widgets import Footer, Header, RichLog
 
 from council.adapters.bus.in_memory import InMemoryBus
+from council.app.tui.cost_notifier import CostNotifier
 from council.app.tui.council_view import CouncilView
+from council.app.tui.health_check import HealthChecker
+from council.app.tui.notices import CouncilNotices
+from council.app.tui.report_writer import DebateReportWriter
 from council.app.tui.widgets import CouncilInput, SynthesizerModal
 from council.domain.debate_service import DebateService
 from council.domain.draft_analysis import analyze_drafts
@@ -68,8 +72,6 @@ class CouncilApp(App):
     ) -> None:
         super().__init__()
         self._elders = elders
-        self._store = store
-        self._clock = clock
         self._pack_loader = pack_loader
         self._pack_name = pack_name
         self._using_openrouter = using_openrouter
@@ -78,16 +80,22 @@ class CouncilApp(App):
         # rosters and friendlier for drafting (three independent takes).
         # "full" runs R1+R2 back-to-back as the legacy TUI behavior.
         self._mode: Literal["r1_only", "full"] = mode
-        self._prev_cost_total: float = 0.0
         self._bus = InMemoryBus()
         self._service = DebateService(elders=elders, store=store, clock=clock, bus=self._bus)
         self._debate: Debate | None = None
         self.awaiting_decision: bool = False
         self.is_finished: bool = False
+        # Public buffer observed by e2e tests (via ``app.rendered_lines``).
+        # CouncilNotices appends here on every write.
         self.rendered_lines: list[str] = []
         self._tasks: set[asyncio.Task] = set()
         self._view = CouncilView(clock=clock)
-        self._report_store = report_store
+        self._notices: CouncilNotices | None = None  # set in on_mount
+        self._health_checker = HealthChecker(elders=elders, labels=self._ELDER_LABELS)
+        self._cost_notifier = CostNotifier(elders=elders)
+        self._report_writer = DebateReportWriter(
+            service=self._service, view=self._view, report_store=report_store
+        )
 
     def _spawn(self, coro) -> asyncio.Task:
         task = asyncio.create_task(coro)
@@ -103,6 +111,10 @@ class CouncilApp(App):
         yield Footer()
 
     async def on_mount(self) -> None:
+        self._notices = CouncilNotices(
+            log=self.query_one("#notices", RichLog),
+            buffer=self.rendered_lines,
+        )
         self._stream_task = self._spawn(self._consume_events())
         self._input().focus()
         self._spawn(self._run_health_checks())
@@ -143,15 +155,19 @@ class CouncilApp(App):
         self._view.pane(ev.elder).end_thinking_failed(ev.error)
 
     def _on_round_completed(self, ev: RoundCompleted) -> None:
+        assert self._notices is not None
+        # r1_only mode: decision point after R1 (no auto-R2).
+        # full mode: decision point after R2 (R1+R2 auto-chain).
         decision_at = 1 if self._mode == "r1_only" else 2
         if ev.round.number >= decision_at:
             self._set_awaiting_decision(True)
             if ev.round.number == decision_at:
-                self._write_decision_hint()
+                self._notices.decision_hint(self._mode)
+            # Auto-synth modal when all three elders converge (R3+).
             if ev.round.number >= 3 and self._service.rules.is_converged(ev.round):
                 self.run_worker(self._synthesize_worker(), exclusive=True)
         if self._using_openrouter:
-            self._spawn(self._write_cost_notice())
+            self._spawn(self._cost_notifier.emit(self._notices))
 
     def _on_synthesis_completed(self, ev: SynthesisCompleted) -> None:
         self._view.pane("synthesis").end_thinking_completed(ev.answer)
@@ -159,7 +175,7 @@ class CouncilApp(App):
         self.is_finished = True
         self._set_awaiting_decision(False)
         if ev.answer.elder:
-            self._spawn(self._generate_and_write_report(ev.answer.elder))
+            self._spawn(self._write_report(ev.answer.elder))
 
     def _on_user_message_received(self, ev: UserMessageReceived) -> None:
         for pane_key in ("ada", "kai", "mei"):
@@ -170,74 +186,16 @@ class CouncilApp(App):
         self._input().disabled = not value
 
     async def _run_health_checks(self) -> None:
-        async def _probe(elder_id: ElderId) -> tuple[ElderId, bool]:
-            try:
-                ok = await self._elders[elder_id].health_check()
-            except Exception:
-                ok = False
-            return elder_id, ok
-
-        results = await asyncio.gather(*(_probe(eid) for eid in self._elders))
-        unhealthy = [eid for eid, ok in results if not ok]
-        if not unhealthy:
-            return
-        for eid in unhealthy:
-            self._write_notice(
-                f"[yellow]⚠ {self._ELDER_LABELS[eid]} CLI is unavailable or unauthenticated. "
-                f"Install it and run its `login` command before asking a question.[/yellow]"
-            )
-        if len(unhealthy) == len(self._elders):
+        assert self._notices is not None
+        all_unhealthy = await self._health_checker.run(self._notices)
+        if all_unhealthy:
             self._input().disabled = True
-            self._write_notice(
-                "[red]No elders available. Fix the vendor CLI setup above, "
-                "then restart the app.[/red]"
-            )
 
-    def _write_notice(self, line: str) -> None:
-        self.rendered_lines.append(line)
-        self.query_one("#notices", RichLog).write(line)
-
-    def _write_decision_hint(self) -> None:
-        if self._mode == "r1_only":
-            self._write_notice(
-                "[dim]R1 complete. [d] compare drafts (agreements/divergences)  ·  "
-                "[s] synthesise  ·  [c] cross-examination round  ·  [a] finish. "
-                "Read the three drafts above; synthesis tends to flatten committed "
-                "specifics.[/dim]"
-            )
-        else:
-            self._write_notice(
-                "[dim]R1+R2 complete. [d] compare drafts  ·  [s] synthesise  ·  "
-                "[c] continue to another round  ·  [a] abandon.[/dim]"
-            )
-
-    async def _write_cost_notice(self) -> None:
-        from council.adapters.elders.openrouter import (
-            OpenRouterAdapter,
-            format_cost_notice,
-        )
-
-        current = sum(
-            e.session_cost_usd for e in self._elders.values() if isinstance(e, OpenRouterAdapter)
-        )
-        delta = current - self._prev_cost_total
-        self._prev_cost_total = current
-
-        any_or = next(
-            (e for e in self._elders.values() if isinstance(e, OpenRouterAdapter)),
-            None,
-        )
-        used, limit = (0.0, None)
-        if any_or is not None:
-            used, limit = await any_or.fetch_credits()
-
-        line = format_cost_notice(
-            elders=self._elders,
-            round_cost_delta_usd=delta,
-            credits_used=used,
-            credits_limit=limit,
-        )
-        self._write_notice(f"[blue]{line}[/blue]")
+    async def _write_report(self, by: ElderId) -> None:
+        assert self._notices is not None
+        if self._debate is None:
+            return
+        await self._report_writer.write(debate=self._debate, by=by, notices=self._notices)
 
     @on(CouncilInput.Submitted)
     async def _on_input_submitted(self, event: CouncilInput.Submitted) -> None:
@@ -247,6 +205,7 @@ class CouncilApp(App):
         input_widget = self._input()
         input_widget.clear()
         if self._debate is None:
+            # First submission — use as the initial prompt.
             pack = self._pack_loader.load(self._pack_name)
             self._debate = Debate(
                 id=str(uuid.uuid4()),
@@ -260,34 +219,19 @@ class CouncilApp(App):
             self._view.focus()
             self._spawn(self._opening_exchange())
         else:
+            # Between-round user message.
             if not self.awaiting_decision:
                 return
             self._spawn(self._service.add_user_message(self._debate, text))
 
-    async def _generate_and_write_report(self, by: ElderId) -> None:
-        if self._debate is None:
-            return
-        try:
-            markdown = await self._service.generate_report(self._debate, by=by)
-        except Exception as ex:
-            self._write_notice(f"[yellow]Report generation failed: {ex}[/yellow]")
-            return
-        self._view.pane("synthesis").append_report(markdown)
-        if self._report_store is not None:
-            try:
-                path = self._report_store.save(debate_id=self._debate.id, markdown=markdown)
-                self._write_notice(f"[blue]Debate report saved to {path}[/blue]")
-            except Exception as ex:
-                self._write_notice(f"[yellow]Report file write failed: {ex}[/yellow]")
-
     async def _opening_exchange(self) -> None:
         if self._debate is None:
             return
-        await self._service.run_round(self._debate)
+        await self._service.run_round(self._debate)  # R1
         if self._debate.status != "in_progress":
             return
         if self._mode == "full":
-            await self._service.run_round(self._debate)
+            await self._service.run_round(self._debate)  # R2
 
     async def action_continue_round(self) -> None:
         if not self.awaiting_decision or self._debate is None:
@@ -320,15 +264,16 @@ class CouncilApp(App):
         self.run_worker(self._analyze_drafts_worker(), exclusive=False)
 
     async def _analyze_drafts_worker(self) -> None:
+        assert self._notices is not None
         if self._debate is None:
             return
         analyzer_id: ElderId = "ada"
         await self._view.show_analysis_pane()
-        self._write_notice(f"[dim]Comparing the three drafts (analyst: {analyzer_id})…[/dim]")
+        self._notices.write(f"[dim]Comparing the three drafts (analyst: {analyzer_id})…[/dim]")
         try:
             markdown = await analyze_drafts(self._debate, analyzer=self._elders[analyzer_id])
         except Exception as ex:
-            self._write_notice(f"[yellow]Draft analysis failed: {ex}[/yellow]")
+            self._notices.write(f"[yellow]Draft analysis failed: {ex}[/yellow]")
             return
         self._view.pane("analysis").append_analysis(markdown, by=analyzer_id.capitalize())
         self._view.pane("analysis").focus()

--- a/council/app/tui/cost_notifier.py
+++ b/council/app/tui/cost_notifier.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from council.app.tui.notices import CouncilNotices
+from council.domain.models import ElderId
+from council.domain.ports import ElderPort
+
+
+class CostNotifier:
+    """Emits OpenRouter cost deltas as blue notices, round-by-round.
+
+    Only meaningful when at least one elder is an ``OpenRouterAdapter``;
+    for subprocess-only rosters the emit is a no-op (delta is 0 and the
+    formatted notice reflects that).
+    """
+
+    def __init__(self, elders: dict[ElderId, ElderPort]) -> None:
+        self._elders = elders
+        self._prev_total: float = 0.0
+
+    async def emit(self, notices: CouncilNotices) -> None:
+        from council.adapters.elders.openrouter import (
+            OpenRouterAdapter,
+            format_cost_notice,
+        )
+
+        current = sum(
+            e.session_cost_usd for e in self._elders.values() if isinstance(e, OpenRouterAdapter)
+        )
+        delta = current - self._prev_total
+        self._prev_total = current
+
+        any_or = next(
+            (e for e in self._elders.values() if isinstance(e, OpenRouterAdapter)),
+            None,
+        )
+        used, limit = (0.0, None)
+        if any_or is not None:
+            used, limit = await any_or.fetch_credits()
+
+        line = format_cost_notice(
+            elders=self._elders,
+            round_cost_delta_usd=delta,
+            credits_used=used,
+            credits_limit=limit,
+        )
+        notices.write(f"[blue]{line}[/blue]")

--- a/council/app/tui/health_check.py
+++ b/council/app/tui/health_check.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+
+from council.app.tui.notices import CouncilNotices
+from council.domain.models import ElderId
+from council.domain.ports import ElderPort
+
+
+class HealthChecker:
+    """Probe elder CLIs and surface unavailability notices."""
+
+    def __init__(
+        self,
+        *,
+        elders: dict[ElderId, ElderPort],
+        labels: dict[ElderId, str],
+    ) -> None:
+        self._elders = elders
+        self._labels = labels
+
+    async def run(self, notices: CouncilNotices) -> bool:
+        """Run all probes. Returns True iff every elder is unhealthy
+        (caller should disable input because nothing can answer).
+        """
+        results = await asyncio.gather(*(self._probe(eid) for eid in self._elders))
+        unhealthy = [eid for eid, ok in results if not ok]
+        if not unhealthy:
+            return False
+        for eid in unhealthy:
+            notices.write(
+                f"[yellow]⚠ {self._labels[eid]} CLI is unavailable or unauthenticated. "
+                f"Install it and run its `login` command before asking a question.[/yellow]"
+            )
+        if len(unhealthy) == len(self._elders):
+            notices.write(
+                "[red]No elders available. Fix the vendor CLI setup above, "
+                "then restart the app.[/red]"
+            )
+            return True
+        return False
+
+    async def _probe(self, elder_id: ElderId) -> tuple[ElderId, bool]:
+        try:
+            ok = await self._elders[elder_id].health_check()
+        except Exception:
+            ok = False
+        return elder_id, ok

--- a/council/app/tui/notices.py
+++ b/council/app/tui/notices.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from textual.widgets import RichLog
+
+
+class CouncilNotices:
+    """Append-only notice log wrapping the `#notices` RichLog.
+
+    Writes go to both the widget (for display) and a shared buffer
+    (kept on the app for test observability via ``app.rendered_lines``).
+    """
+
+    def __init__(self, *, log: RichLog, buffer: list[str]) -> None:
+        self._log = log
+        self._buffer = buffer
+
+    def write(self, line: str) -> None:
+        self._buffer.append(line)
+        self._log.write(line)
+
+    def decision_hint(self, mode: Literal["r1_only", "full"]) -> None:
+        """Surface keybinding affordances once per debate, at the first
+        decision point. Non-intrusive but discoverable — the keybindings
+        themselves are ``show=False`` in the Footer.
+        """
+        if mode == "r1_only":
+            self.write(
+                "[dim]R1 complete. [d] compare drafts (agreements/divergences)  ·  "
+                "[s] synthesise  ·  [c] cross-examination round  ·  [a] finish. "
+                "Read the three drafts above; synthesis tends to flatten committed "
+                "specifics.[/dim]"
+            )
+        else:
+            self.write(
+                "[dim]R1+R2 complete. [d] compare drafts  ·  [s] synthesise  ·  "
+                "[c] continue to another round  ·  [a] abandon.[/dim]"
+            )

--- a/council/app/tui/report_writer.py
+++ b/council/app/tui/report_writer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from council.app.tui.council_view import CouncilView
+from council.app.tui.notices import CouncilNotices
+from council.domain.debate_service import DebateService
+from council.domain.models import Debate, ElderId
+
+
+class DebateReportWriter:
+    """Generate the debate report, render it in the synthesis pane, save to disk."""
+
+    def __init__(
+        self,
+        *,
+        service: DebateService,
+        view: CouncilView,
+        report_store,  # ReportFileStore | None
+    ) -> None:
+        self._service = service
+        self._view = view
+        self._report_store = report_store
+
+    async def write(
+        self,
+        *,
+        debate: Debate,
+        by: ElderId,
+        notices: CouncilNotices,
+    ) -> None:
+        try:
+            markdown = await self._service.generate_report(debate, by=by)
+        except Exception as ex:
+            notices.write(f"[yellow]Report generation failed: {ex}[/yellow]")
+            return
+        self._view.pane("synthesis").append_report(markdown)
+        if self._report_store is None:
+            return
+        try:
+            path = self._report_store.save(debate_id=debate.id, markdown=markdown)
+            notices.write(f"[blue]Debate report saved to {path}[/blue]")
+        except Exception as ex:
+            notices.write(f"[yellow]Report file write failed: {ex}[/yellow]")


### PR DESCRIPTION
## Summary

- Split `council/app/headless/runner.py` into `printing.py` (stdout formatters), `rounds.py` (policy + round execution + best-R1 selection), and `reporting.py` (synthesis/preference/report/summary/cost pipeline). `runner.py` keeps `run_headless` as a thin orchestrator.
- Extracted `CouncilApp` chunky concerns into collaborators: `CouncilNotices`, `HealthChecker`, `CostNotifier`, `DebateReportWriter`. `app.py` now holds lifecycle, event dispatch, action handlers, and workers.
- No behavior change. Public API preserved (`app.rendered_lines`, `app.awaiting_decision`, `app.is_finished`, `council.app.headless.main.run_headless`).

## Test plan

- [x] 521/521 existing tests pass (unit + contract + integration + e2e)
- [x] `ruff check` clean
- [x] `_print_rounds` stdout format verified — real newlines, no `\n` regression
- [x] `council-headless --help` still renders help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)