### PR TITLE
test: backfill unit tests for headless modules and TUI collaborators

### DIFF
--- a/tests/unit/test_headless_printing.py
+++ b/tests/unit/test_headless_printing.py
@@ -1,0 +1,258 @@
+import io
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+
+from council.app.headless.printing import (
+    print_best_r1_only_deliverable,
+    print_best_r1_pick,
+    print_best_r1_unavailable,
+    print_max_rounds_exhausted,
+    print_policy_warning,
+    print_preference,
+    print_report,
+    print_report_failed,
+    print_rounds,
+    print_run_summary_path,
+    print_synthesis,
+)
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    ElderError,
+    Round,
+    Turn,
+)
+from council.domain.preference import JudgeVerdict, MultiJudgeVerdict, PreferenceVerdict
+from council.domain.synthesis_output import SynthesisOutput
+
+
+def _capture(fn, *args, **kwargs) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        fn(*args, **kwargs)
+    return buf.getvalue()
+
+
+def _ans(elder, text, *, error=None):
+    return ElderAnswer(
+        elder=elder,
+        text=text,
+        error=error,
+        agreed=None,
+        created_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+    )
+
+
+def _debate_with_rounds(*rounds) -> Debate:
+    return Debate(
+        id="t",
+        prompt="?",
+        pack=CouncilPack(name="bare", shared_context=None, personas={}),
+        rounds=list(rounds),
+        status="in_progress",
+        synthesis=None,
+    )
+
+
+class TestPrintRounds:
+    def test_emits_real_newlines_not_literal_backslash_n(self):
+        # Regression guard for PR 15: the extraction accidentally wrote
+        # "\\n" in the f-strings, emitting the literal two-character
+        # sequence instead of a newline. This check fails if that ever
+        # recurs.
+        debate = _debate_with_rounds(
+            Round(number=1, turns=[Turn(elder="ada", answer=_ans("ada", "hi"))]),
+        )
+        out = _capture(print_rounds, debate)
+        # Strip all real newlines; any remaining "\n" is the literal bug.
+        assert "\\n" not in out.replace("\n", "")
+
+    def test_prints_round_header_and_labels(self):
+        debate = _debate_with_rounds(
+            Round(
+                number=2,
+                turns=[
+                    Turn(elder="ada", answer=_ans("ada", "alpha")),
+                    Turn(elder="kai", answer=_ans("kai", "beta")),
+                ],
+            ),
+        )
+        out = _capture(print_rounds, debate)
+        assert "--- Round 2 ---" in out
+        assert "[Ada] alpha" in out
+        assert "[Kai] beta" in out
+
+    def test_formats_error_turn(self):
+        err = ElderError(elder="mei", kind="timeout", detail="slow")
+        debate = _debate_with_rounds(
+            Round(
+                number=1,
+                turns=[Turn(elder="mei", answer=_ans("mei", "", error=err))],
+            ),
+        )
+        out = _capture(print_rounds, debate)
+        assert "[Mei] ERROR timeout: slow" in out
+
+    def test_uses_elder_label_not_raw_id(self):
+        debate = _debate_with_rounds(
+            Round(number=1, turns=[Turn(elder="kai", answer=_ans("kai", "x"))]),
+        )
+        out = _capture(print_rounds, debate)
+        assert "[Kai]" in out
+        assert "[kai]" not in out
+
+
+class TestPrintBestR1:
+    def test_pick_uses_label(self):
+        out = _capture(print_best_r1_pick, "kai", "clearest")
+        assert "Best R1 (judge-picked): Kai" in out
+        assert "clearest" in out
+
+    def test_unavailable_message(self):
+        out = _capture(print_best_r1_unavailable)
+        assert "Best-R1 baseline unavailable" in out
+
+
+class TestPrintSynthesis:
+    def _structured(self, *, why="", disagreements=()):
+        return SynthesisOutput(
+            answer="final answer",
+            why=why,
+            disagreements=disagreements,
+            raw="ANSWER:\nfinal answer",
+        )
+
+    def test_shows_header_and_body(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(),
+            synthesizer="ada",
+            risk_note=None,
+        )
+        assert "[Synthesis by Ada]" in out
+        assert "final answer" in out
+
+    def test_shows_risk_note_when_provided(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(),
+            synthesizer="ada",
+            risk_note="[note] careful now",
+        )
+        assert "[note] careful now" in out
+
+    def test_omits_why_when_empty(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(why=""),
+            synthesizer="ada",
+            risk_note=None,
+        )
+        assert "Why:" not in out
+
+    def test_prints_why_when_present(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(why="because reasons"),
+            synthesizer="ada",
+            risk_note=None,
+        )
+        assert "Why: because reasons" in out
+
+    def test_none_material_when_no_disagreements(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(disagreements=()),
+            synthesizer="ada",
+            risk_note=None,
+        )
+        assert "Disagreements: none material." in out
+
+    def test_lists_disagreements_when_present(self):
+        out = _capture(
+            print_synthesis,
+            structured=self._structured(disagreements=("alpha", "beta")),
+            synthesizer="ada",
+            risk_note=None,
+        )
+        assert "- alpha" in out
+        assert "- beta" in out
+
+
+class TestPrintPreference:
+    def test_single_verdict_formats_winner(self):
+        v = PreferenceVerdict(winner="synthesis", reason="it's tighter", raw="")
+        out = _capture(print_preference, v)
+        assert "[Preference judge]" in out
+        assert "synthesis — it's tighter" in out
+
+    def test_multi_lists_aggregate_and_per_judge(self):
+        per = (
+            JudgeVerdict(
+                judge_model="google/gemini-2.5-flash",
+                verdict=PreferenceVerdict(winner="best_r1", reason="r1 concrete", raw=""),
+            ),
+            JudgeVerdict(
+                judge_model="anthropic/claude-haiku-4.5",
+                verdict=PreferenceVerdict(winner="synthesis", reason="synth fuller", raw=""),
+            ),
+        )
+        mv = MultiJudgeVerdict(verdicts=per, aggregate="tie", unanimous=False)
+        out = _capture(print_preference, mv)
+        assert "aggregate=tie" in out
+        assert "unanimous=False" in out
+        assert "n_judges=2" in out
+        assert "google/gemini-2.5-flash: best_r1 — r1 concrete" in out
+        assert "anthropic/claude-haiku-4.5: synthesis — synth fuller" in out
+
+
+class TestPrintReport:
+    def test_without_save_path_omits_saved_line(self):
+        out = _capture(print_report, "# report body", saved_to=None)
+        assert "--- Debate report ---" in out
+        assert "# report body" in out
+        assert "Report saved to" not in out
+
+    def test_with_save_path_shows_saved_line(self):
+        out = _capture(print_report, "# report", saved_to=Path("/tmp/x.md"))
+        assert "Report saved to /tmp/x.md" in out
+
+
+class TestPrintBestR1OnlyDeliverable:
+    def test_prints_answer_when_elder_and_text_present(self):
+        debate = _debate_with_rounds()
+        debate.best_r1_elder = "kai"
+        out = _capture(print_best_r1_only_deliverable, debate, "the answer")
+        assert "[Answer (best-R1, Kai)] the answer" in out
+
+    def test_warns_when_no_elder(self):
+        debate = _debate_with_rounds()
+        out = _capture(print_best_r1_only_deliverable, debate, None)
+        assert "[warning] best-R1-only mode but no judge available" in out
+
+    def test_warns_when_no_text(self):
+        debate = _debate_with_rounds()
+        debate.best_r1_elder = "mei"
+        out = _capture(print_best_r1_only_deliverable, debate, None)
+        assert "[warning]" in out
+
+
+class TestMiscPrints:
+    def test_run_summary_path(self):
+        out = _capture(print_run_summary_path, Path("/tmp/sum.json"))
+        assert "[run summary] /tmp/sum.json" in out
+
+    def test_policy_warning(self):
+        out = _capture(print_policy_warning, "homogeneous roster")
+        assert "[warning] homogeneous roster" in out
+
+    def test_max_rounds_exhausted(self):
+        out = _capture(print_max_rounds_exhausted, 6)
+        assert "[warning] Hit policy max_rounds=6" in out
+        assert "Synthesising best-effort" in out
+
+    def test_report_failed(self):
+        out = _capture(print_report_failed, RuntimeError("boom"))
+        assert "[warning] Report generation failed: boom" in out

--- a/tests/unit/test_headless_reporting.py
+++ b/tests/unit/test_headless_reporting.py
@@ -1,0 +1,345 @@
+import io
+import json
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+from council.app.headless.reporting import (
+    emit_openrouter_cost_notice,
+    generate_and_save_report,
+    judge_preference_verdict,
+    run_synthesis,
+    synthesis_risk_note,
+    write_summary_sidecar,
+)
+from council.domain.debate_policy import DebatePolicy
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    Round,
+    Turn,
+)
+from council.domain.preference import (
+    JudgeVerdict,
+    MultiJudgeVerdict,
+    PreferenceVerdict,
+)
+from council.domain.roster import RosterSpec
+from council.domain.synthesis_output import SynthesisOutput
+
+
+def _policy(*, mode="full_debate", synthesise=True, max_rounds=3):
+    return DebatePolicy(
+        mode=mode,
+        max_rounds=max_rounds,
+        synthesise=synthesise,
+        always_compute_best_r1=True,
+        warning=None,
+    )
+
+
+def _roster(models=None):
+    return RosterSpec(name="t", models=models or {"ada": "a", "kai": "b", "mei": "c"})
+
+
+def _ans(elder="ada", text="hi"):
+    return ElderAnswer(
+        elder=elder,
+        text=text,
+        error=None,
+        agreed=None,
+        created_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+    )
+
+
+def _debate():
+    return Debate(
+        id="debate-xyz",
+        prompt="q",
+        pack=CouncilPack(name="bare", shared_context=None, personas={}),
+        rounds=[Round(number=1, turns=[Turn(elder="ada", answer=_ans())])],
+        status="in_progress",
+        synthesis=None,
+    )
+
+
+def _structured(answer="final"):
+    return SynthesisOutput(answer=answer, why="", disagreements=(), raw=f"ANSWER:\n{answer}")
+
+
+class TestSynthesisRiskNote:
+    def test_none_when_policy_skips_synthesis(self):
+        assert synthesis_risk_note(policy=_policy(synthesise=False), roster_spec=_roster()) is None
+
+    def test_none_when_no_roster(self):
+        assert synthesis_risk_note(policy=_policy(), roster_spec=None) is None
+
+    def test_none_when_roster_has_no_models(self):
+        assert (
+            synthesis_risk_note(policy=_policy(), roster_spec=RosterSpec(name="t", models={}))
+            is None
+        )
+
+    def test_note_on_low_diversity(self, monkeypatch):
+        # Force classification by patching score_roster.
+        from council.domain.diversity import DiversityScore
+
+        monkeypatch.setattr(
+            "council.app.headless.reporting.score_roster",
+            lambda _r: DiversityScore(
+                classification="low",
+                provider_count=1,
+                identical_model_count=0,
+                flags=(),
+                rationale="t",
+            ),
+        )
+        note = synthesis_risk_note(policy=_policy(), roster_spec=_roster())
+        assert note is not None
+        assert "low-diversity" in note
+
+    def test_note_on_medium_diversity(self, monkeypatch):
+        from council.domain.diversity import DiversityScore
+
+        monkeypatch.setattr(
+            "council.app.headless.reporting.score_roster",
+            lambda _r: DiversityScore(
+                classification="medium",
+                provider_count=2,
+                identical_model_count=0,
+                flags=(),
+                rationale="t",
+            ),
+        )
+        note = synthesis_risk_note(policy=_policy(), roster_spec=_roster())
+        assert note is not None
+        assert "medium-diversity" in note
+
+    def test_omitted_on_high_diversity(self, monkeypatch):
+        from council.domain.diversity import DiversityScore
+
+        monkeypatch.setattr(
+            "council.app.headless.reporting.score_roster",
+            lambda _r: DiversityScore(
+                classification="high",
+                provider_count=3,
+                identical_model_count=0,
+                flags=(),
+                rationale="t",
+            ),
+        )
+        assert synthesis_risk_note(policy=_policy(), roster_spec=_roster()) is None
+
+
+class TestRunSynthesis:
+    async def test_returns_parsed_synthesis(self):
+        svc = MagicMock()
+        synth_answer = _ans("ada", "ANSWER:\nfinal body")
+        svc.synthesize = AsyncMock(return_value=synth_answer)
+        debate = _debate()
+
+        result = await run_synthesis(svc=svc, debate=debate, synthesizer="ada")
+
+        svc.synthesize.assert_awaited_once_with(debate, by="ada")
+        assert result.answer == "final body"
+
+
+class TestJudgePreferenceVerdict:
+    async def test_multi_judge_path_takes_precedence(self, monkeypatch):
+        async def _fake_multi(**kw):
+            assert kw["question"] == "q"
+            return MultiJudgeVerdict(verdicts=(), aggregate="synthesis", unanimous=True)
+
+        async def _fake_single(**kw):
+            raise AssertionError("single should not be called when multi provided")
+
+        monkeypatch.setattr("council.app.headless.reporting.judge_preference_multi", _fake_multi)
+        monkeypatch.setattr("council.app.headless.reporting.judge_preference", _fake_single)
+
+        out = await judge_preference_verdict(
+            prompt="q",
+            synthesis_answer="s",
+            best_r1_text="r",
+            preference_judge=MagicMock(),  # would be ignored
+            preference_judges=[("model-a", MagicMock())],
+        )
+        assert isinstance(out, MultiJudgeVerdict)
+
+    async def test_falls_back_to_single_judge(self, monkeypatch):
+        sentinel = PreferenceVerdict(winner="best_r1", reason="r", raw="")
+
+        async def _fake_single(**kw):
+            return sentinel
+
+        monkeypatch.setattr("council.app.headless.reporting.judge_preference", _fake_single)
+
+        out = await judge_preference_verdict(
+            prompt="q",
+            synthesis_answer="s",
+            best_r1_text="r",
+            preference_judge=MagicMock(),
+            preference_judges=None,
+        )
+        assert out is sentinel
+
+    async def test_returns_none_when_neither_configured(self):
+        out = await judge_preference_verdict(
+            prompt="q",
+            synthesis_answer="s",
+            best_r1_text="r",
+            preference_judge=None,
+            preference_judges=None,
+        )
+        assert out is None
+
+
+class TestGenerateAndSaveReport:
+    async def test_success_and_saves_when_store_present(self):
+        svc = MagicMock()
+        svc.generate_report = AsyncMock(return_value="# body")
+        store = MagicMock()
+        store.save.return_value = Path("/tmp/xyz.md")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await generate_and_save_report(
+                svc=svc,
+                debate=_debate(),
+                synthesizer="ada",
+                risk_note=None,
+                report_store=store,
+            )
+        assert svc.generate_report.await_count == 1
+        store.save.assert_called_once()
+        out = buf.getvalue()
+        assert "# body" in out
+        assert "Report saved to /tmp/xyz.md" in out
+
+    async def test_success_without_store_skips_save(self):
+        svc = MagicMock()
+        svc.generate_report = AsyncMock(return_value="# body")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await generate_and_save_report(
+                svc=svc,
+                debate=_debate(),
+                synthesizer="ada",
+                risk_note=None,
+                report_store=None,
+            )
+        out = buf.getvalue()
+        assert "# body" in out
+        assert "Report saved to" not in out
+
+    async def test_failure_is_caught_and_prints_warning(self):
+        svc = MagicMock()
+        svc.generate_report = AsyncMock(side_effect=RuntimeError("llm down"))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await generate_and_save_report(
+                svc=svc,
+                debate=_debate(),
+                synthesizer="ada",
+                risk_note=None,
+                report_store=MagicMock(),
+            )
+        assert "Report generation failed: llm down" in buf.getvalue()
+
+    async def test_passes_risk_note_to_generate_report(self):
+        svc = MagicMock()
+        svc.generate_report = AsyncMock(return_value="# body")
+        await generate_and_save_report(
+            svc=svc,
+            debate=_debate(),
+            synthesizer="ada",
+            risk_note="[note] be careful",
+            report_store=None,
+        )
+        kwargs = svc.generate_report.await_args.kwargs
+        assert kwargs["synthesis_risk_note"] == "[note] be careful"
+
+
+class TestWriteSummarySidecar:
+    def test_captures_preference_judge_model_for_single(self, tmp_path: Path):
+        debate = _debate()
+        pref_judge = MagicMock()
+        pref_judge.model = "google/gemini-2.5-flash"
+        pref = PreferenceVerdict(winner="synthesis", reason="", raw="")
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            write_summary_sidecar(
+                debate=debate,
+                roster_spec=_roster(),
+                policy=_policy(),
+                structured=_structured(),
+                preference=pref,
+                preference_judge=pref_judge,
+                root=tmp_path,
+            )
+        # The summary was written somewhere under tmp_path — locate it
+        # and assert the judge model carried through.
+        files = list(tmp_path.rglob("*.json"))
+        assert files, "expected a summary json to be written"
+        payload = json.loads(files[0].read_text())
+        # Provenance shows up under preference somewhere — scan the raw text.
+        assert "google/gemini-2.5-flash" in files[0].read_text(), payload
+
+    def test_multi_verdict_does_not_set_single_model_field(self, tmp_path: Path):
+        debate = _debate()
+        pref = MultiJudgeVerdict(
+            verdicts=(
+                JudgeVerdict(
+                    judge_model="anthropic/claude-haiku-4.5",
+                    verdict=PreferenceVerdict(winner="synthesis", reason="", raw=""),
+                ),
+            ),
+            aggregate="synthesis",
+            unanimous=True,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            write_summary_sidecar(
+                debate=debate,
+                roster_spec=_roster(),
+                policy=_policy(),
+                structured=_structured(),
+                preference=pref,
+                preference_judge=MagicMock(model="single-should-be-ignored"),
+                root=tmp_path,
+            )
+        text = next(tmp_path.rglob("*.json")).read_text()
+        assert "single-should-be-ignored" not in text
+        assert "anthropic/claude-haiku-4.5" in text
+
+    def test_prints_sidecar_path(self, tmp_path: Path):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            write_summary_sidecar(
+                debate=_debate(),
+                roster_spec=None,
+                policy=_policy(),
+                structured=None,
+                preference=None,
+                preference_judge=None,
+                root=tmp_path,
+            )
+        assert "[run summary]" in buf.getvalue()
+
+
+class TestEmitOpenRouterCostNotice:
+    async def test_no_openrouter_adapters_prints_zero_delta_line(self):
+        # elders dict with non-OpenRouter adapters → sum() over filtered
+        # is 0, credits fetch is skipped, format_cost_notice is still called.
+        from council.adapters.elders.fake import FakeElder
+
+        elders = {"ada": FakeElder(elder_id="ada", replies=[])}
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await emit_openrouter_cost_notice(elders)
+        # Only assertion: something was printed. The exact line shape
+        # depends on format_cost_notice; we don't pin it here — we just
+        # verify the helper doesn't crash on subprocess-only rosters.
+        assert buf.getvalue() != ""

--- a/tests/unit/test_headless_rounds.py
+++ b/tests/unit/test_headless_rounds.py
@@ -1,0 +1,268 @@
+import io
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+
+from council.app.headless.rounds import (
+    resolve_policy,
+    run_debate_rounds,
+    select_best_r1,
+)
+from council.domain.best_r1 import BestR1Selection
+from council.domain.debate_policy import DebatePolicy
+from council.domain.diversity import DiversityScore
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    Round,
+    Turn,
+)
+from council.domain.roster import RosterSpec
+
+
+def _score(classification):
+    return DiversityScore(
+        classification=classification,
+        provider_count=3 if classification == "high" else 1,
+        identical_model_count=0,
+        flags=(),
+        rationale="t",
+    )
+
+
+def _ans(elder, text):
+    return ElderAnswer(
+        elder=elder,
+        text=text,
+        error=None,
+        agreed=None,
+        created_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+    )
+
+
+def _debate() -> Debate:
+    return Debate(
+        id="t",
+        prompt="?",
+        pack=CouncilPack(name="bare", shared_context=None, personas={}),
+        rounds=[],
+        status="in_progress",
+        synthesis=None,
+    )
+
+
+class TestResolvePolicy:
+    def test_user_override_wins(self):
+        override = DebatePolicy(
+            mode="full_debate",
+            max_rounds=4,
+            synthesise=True,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        result = resolve_policy(
+            user_override=override,
+            roster_spec=RosterSpec(
+                name="t", models={"ada": "claude", "kai": "gemini", "mei": "codex"}
+            ),
+            fallback_max_rounds=99,
+        )
+        assert result is override
+
+    def test_roster_drives_policy_when_no_override(self):
+        # High diversity roster → full_debate from policy_for.
+        result = resolve_policy(
+            user_override=None,
+            roster_spec=RosterSpec(
+                name="t",
+                models={
+                    "ada": "anthropic/claude-opus-4.7",
+                    "kai": "google/gemini-2.5-flash",
+                    "mei": "openai/gpt-5-codex",
+                },
+            ),
+            fallback_max_rounds=6,
+        )
+        assert result.mode in ("full_debate", "single_critique", "best_r1_only")
+
+    def test_fallback_when_no_roster(self):
+        result = resolve_policy(
+            user_override=None,
+            roster_spec=None,
+            fallback_max_rounds=5,
+        )
+        assert result.mode == "full_debate"
+        assert result.max_rounds == 5
+        assert result.synthesise is True
+
+    def test_fallback_when_roster_has_no_models(self):
+        result = resolve_policy(
+            user_override=None,
+            roster_spec=RosterSpec(name="t", models={}),
+            fallback_max_rounds=3,
+        )
+        assert result.mode == "full_debate"
+
+
+def _svc(*, converged_after: int = 1):
+    """Async-mocked DebateService that appends a round every run_round call.
+
+    ``converged_after``: the round number at which ``rules.is_converged``
+    first returns True (round 1-indexed in ``debate.rounds``).
+    """
+    debate_rounds_seen = {"n": 0}
+
+    async def _run_round(debate):
+        debate_rounds_seen["n"] += 1
+        debate.rounds.append(Round(number=debate_rounds_seen["n"], turns=[]))
+
+    svc = MagicMock()
+    svc.run_round = AsyncMock(side_effect=_run_round)
+    svc.rules = MagicMock()
+    svc.rules.is_converged = lambda rnd: rnd.number >= converged_after
+    return svc
+
+
+class TestRunDebateRounds:
+    async def test_best_r1_only_runs_one_round(self):
+        debate = _debate()
+        svc = _svc()
+        policy = DebatePolicy(
+            mode="best_r1_only",
+            max_rounds=1,
+            synthesise=False,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        await run_debate_rounds(debate=debate, svc=svc, policy=policy)
+        assert svc.run_round.await_count == 1
+        assert len(debate.rounds) == 1
+
+    async def test_r1_only_runs_one_round(self):
+        debate = _debate()
+        svc = _svc()
+        policy = DebatePolicy(
+            mode="r1_only",
+            max_rounds=1,
+            synthesise=True,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        await run_debate_rounds(debate=debate, svc=svc, policy=policy)
+        assert svc.run_round.await_count == 1
+
+    async def test_single_critique_runs_two_rounds(self):
+        debate = _debate()
+        svc = _svc()
+        policy = DebatePolicy(
+            mode="single_critique",
+            max_rounds=2,
+            synthesise=True,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        await run_debate_rounds(debate=debate, svc=svc, policy=policy)
+        assert svc.run_round.await_count == 2
+
+    async def test_full_debate_runs_until_converged(self):
+        debate = _debate()
+        # Converge on round 3 — so total rounds = 3.
+        svc = _svc(converged_after=3)
+        policy = DebatePolicy(
+            mode="full_debate",
+            max_rounds=6,
+            synthesise=True,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        await run_debate_rounds(debate=debate, svc=svc, policy=policy)
+        assert svc.run_round.await_count == 3
+
+    async def test_full_debate_stops_at_max_rounds_and_warns(self):
+        debate = _debate()
+        # Never converge — loop exits on max_rounds.
+        svc = _svc(converged_after=999)
+        policy = DebatePolicy(
+            mode="full_debate",
+            max_rounds=4,
+            synthesise=True,
+            always_compute_best_r1=True,
+            warning=None,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            await run_debate_rounds(debate=debate, svc=svc, policy=policy)
+        assert svc.run_round.await_count == 4
+        assert "max_rounds=4" in buf.getvalue()
+        assert "without full convergence" in buf.getvalue()
+
+
+class TestSelectBestR1:
+    async def test_no_judge_prints_unavailable_and_returns_none(self):
+        debate = _debate()
+        store = MagicMock()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            out = await select_best_r1(debate=debate, store=store, best_r1_judge=None)
+        assert out is None
+        assert "Best-R1 baseline unavailable" in buf.getvalue()
+        store.save.assert_not_called()
+
+    async def test_happy_path_records_and_returns_text(self, monkeypatch):
+        debate = _debate()
+        debate.rounds.append(
+            Round(
+                number=1,
+                turns=[
+                    Turn(elder="ada", answer=_ans("ada", "ada text")),
+                    Turn(elder="kai", answer=_ans("kai", "kai text")),
+                    Turn(elder="mei", answer=_ans("mei", "mei text")),
+                ],
+            )
+        )
+        store = MagicMock()
+
+        # Stub the selector class's select to return a known pick without
+        # needing a real judge_port round-trip.
+        async def _fake_select(self, d):
+            return BestR1Selection(elder="kai", reason="kai is tightest", raw="best: 2\n")
+
+        monkeypatch.setattr(
+            "council.app.headless.rounds.LLMJudgedBestR1Selector.select",
+            _fake_select,
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            out = await select_best_r1(
+                debate=debate,
+                store=store,
+                best_r1_judge=MagicMock(),
+            )
+
+        assert out == "kai text"
+        assert debate.best_r1_elder == "kai"
+        store.save.assert_called_once_with(debate)
+        assert "Best R1 (judge-picked): Kai" in buf.getvalue()
+
+    async def test_selector_returns_none_does_not_mutate(self, monkeypatch):
+        debate = _debate()
+        debate.rounds.append(Round(number=1, turns=[]))  # no turns → selector yields None
+        store = MagicMock()
+
+        async def _fake_select(self, d):
+            return None
+
+        monkeypatch.setattr(
+            "council.app.headless.rounds.LLMJudgedBestR1Selector.select",
+            _fake_select,
+        )
+        out = await select_best_r1(
+            debate=debate,
+            store=store,
+            best_r1_judge=MagicMock(),
+        )
+        assert out is None
+        assert debate.best_r1_elder is None
+        store.save.assert_not_called()

--- a/tests/unit/test_tui_cost_notifier.py
+++ b/tests/unit/test_tui_cost_notifier.py
@@ -1,0 +1,98 @@
+from council.adapters.elders.fake import FakeElder
+from council.app.tui.cost_notifier import CostNotifier
+from council.app.tui.notices import CouncilNotices
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.written: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.written.append(line)
+
+
+def _notices():
+    buf: list[str] = []
+    return CouncilNotices(log=_StubLog(), buffer=buf), buf
+
+
+class _FakeOpenRouter:
+    """Minimal stand-in for OpenRouterAdapter that satisfies the
+    isinstance check by actually *being* OpenRouterAdapter — we can't
+    fake that without patching the symbol. Instead the CostNotifier
+    tests exercise the non-OpenRouter (subprocess-only) path, which
+    is the common case for tests.
+    """
+
+
+class TestCostNotifierWithoutOpenRouter:
+    async def test_emit_writes_a_line_with_zero_delta(self):
+        # No OpenRouter adapters present → delta is 0, credits are
+        # (0.0, None), format_cost_notice still produces a notice.
+        elders = {
+            "ada": FakeElder(elder_id="ada", replies=[]),
+            "kai": FakeElder(elder_id="kai", replies=[]),
+            "mei": FakeElder(elder_id="mei", replies=[]),
+        }
+        notifier = CostNotifier(elders=elders)
+        notices, buf = _notices()
+
+        await notifier.emit(notices)
+
+        assert len(buf) == 1
+        # Line is a blue-wrapped notice.
+        assert buf[0].startswith("[blue]") and buf[0].endswith("[/blue]")
+
+    async def test_prev_total_starts_at_zero(self):
+        notifier = CostNotifier(
+            elders={"ada": FakeElder(elder_id="ada", replies=[])},
+        )
+        assert notifier._prev_total == 0.0
+
+
+class TestCostNotifierDeltaComputation:
+    async def test_delta_accumulates_across_calls(self, monkeypatch):
+        """Patch the OpenRouter symbol + format_cost_notice to observe
+        that the notifier subtracts _prev_total on each emit. This is
+        the one piece of CostNotifier logic that matters — the rest is
+        mostly glue.
+        """
+        captured_deltas: list[float] = []
+
+        class _FakeAdapter:
+            def __init__(self, cost: float):
+                self.session_cost_usd = cost
+
+            async def fetch_credits(self):
+                return (0.0, None)
+
+        # Monkeypatch the isinstance check target and the formatter in
+        # the cost_notifier module's namespace — imports happen inside
+        # .emit() via ``from … import`` so we patch the source module.
+        import council.adapters.elders.openrouter as or_mod
+
+        monkeypatch.setattr(or_mod, "OpenRouterAdapter", _FakeAdapter)
+
+        def _fmt(*, elders, round_cost_delta_usd, credits_used, credits_limit):
+            captured_deltas.append(round_cost_delta_usd)
+            return "ok"
+
+        monkeypatch.setattr(or_mod, "format_cost_notice", _fmt)
+
+        a1 = _FakeAdapter(cost=1.0)
+        a2 = _FakeAdapter(cost=2.5)
+        notifier = CostNotifier(elders={"ada": a1, "kai": a2})
+        notices, _ = _notices()
+
+        # First emit: delta = (1.0 + 2.5) - 0 = 3.5
+        await notifier.emit(notices)
+
+        # Mutate the cost totals to simulate more LLM work done.
+        a1.session_cost_usd = 1.5
+        a2.session_cost_usd = 3.0
+
+        # Second emit: delta = (1.5 + 3.0) - 3.5 = 1.0
+        await notifier.emit(notices)
+
+        assert captured_deltas == [3.5, 1.0]
+        assert notifier._prev_total == 4.5

--- a/tests/unit/test_tui_health_check.py
+++ b/tests/unit/test_tui_health_check.py
@@ -1,0 +1,96 @@
+from council.adapters.elders.fake import FakeElder
+from council.app.tui.health_check import HealthChecker
+from council.app.tui.notices import CouncilNotices
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.written: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.written.append(line)
+
+
+def _notices() -> tuple[CouncilNotices, list[str]]:
+    buf: list[str] = []
+    return CouncilNotices(log=_StubLog(), buffer=buf), buf
+
+
+_LABELS = {"ada": "Ada", "kai": "Kai", "mei": "Mei"}
+
+
+class _RaisingElder:
+    """Probe raises — must be treated as unhealthy."""
+
+    def __init__(self) -> None:
+        self.called = 0
+
+    async def health_check(self) -> bool:
+        self.called += 1
+        raise RuntimeError("boom")
+
+
+class TestHealthChecker:
+    async def test_all_healthy_returns_false_and_writes_nothing(self):
+        elders = {
+            "ada": FakeElder(elder_id="ada", replies=[], healthy=True),
+            "kai": FakeElder(elder_id="kai", replies=[], healthy=True),
+            "mei": FakeElder(elder_id="mei", replies=[], healthy=True),
+        }
+        notices, buf = _notices()
+        checker = HealthChecker(elders=elders, labels=_LABELS)
+
+        all_down = await checker.run(notices)
+
+        assert all_down is False
+        assert buf == []
+
+    async def test_some_unhealthy_writes_per_elder_notice_returns_false(self):
+        elders = {
+            "ada": FakeElder(elder_id="ada", replies=[], healthy=True),
+            "kai": FakeElder(elder_id="kai", replies=[], healthy=False),
+            "mei": FakeElder(elder_id="mei", replies=[], healthy=True),
+        }
+        notices, buf = _notices()
+        checker = HealthChecker(elders=elders, labels=_LABELS)
+
+        all_down = await checker.run(notices)
+
+        assert all_down is False
+        assert any("Kai CLI is unavailable" in line for line in buf)
+        assert not any("Ada CLI is unavailable" in line for line in buf)
+        # No "No elders available" red line when some are still healthy.
+        assert not any("No elders available" in line for line in buf)
+
+    async def test_all_unhealthy_returns_true_and_writes_red_followup(self):
+        elders = {
+            "ada": FakeElder(elder_id="ada", replies=[], healthy=False),
+            "kai": FakeElder(elder_id="kai", replies=[], healthy=False),
+            "mei": FakeElder(elder_id="mei", replies=[], healthy=False),
+        }
+        notices, buf = _notices()
+        checker = HealthChecker(elders=elders, labels=_LABELS)
+
+        all_down = await checker.run(notices)
+
+        assert all_down is True
+        assert any("No elders available" in line for line in buf)
+        # All three per-elder notices present.
+        for name in ("Ada", "Kai", "Mei"):
+            assert any(f"{name} CLI is unavailable" in line for line in buf)
+
+    async def test_probe_exception_treated_as_unhealthy(self):
+        raising = _RaisingElder()
+        elders = {
+            "ada": raising,
+            "kai": FakeElder(elder_id="kai", replies=[], healthy=True),
+            "mei": FakeElder(elder_id="mei", replies=[], healthy=True),
+        }
+        notices, buf = _notices()
+        checker = HealthChecker(elders=elders, labels=_LABELS)
+
+        all_down = await checker.run(notices)
+
+        assert all_down is False
+        assert raising.called == 1
+        assert any("Ada CLI is unavailable" in line for line in buf)

--- a/tests/unit/test_tui_notices.py
+++ b/tests/unit/test_tui_notices.py
@@ -1,0 +1,48 @@
+from council.app.tui.notices import CouncilNotices
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.written: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.written.append(line)
+
+
+class TestCouncilNoticesWrite:
+    def test_appends_to_both_buffer_and_log(self):
+        log = _StubLog()
+        buffer: list[str] = []
+        notices = CouncilNotices(log=log, buffer=buffer)
+
+        notices.write("first")
+        notices.write("second")
+
+        assert buffer == ["first", "second"]
+        assert log.written == ["first", "second"]
+
+
+class TestCouncilNoticesDecisionHint:
+    def test_r1_only_hint_mentions_keybindings(self):
+        log = _StubLog()
+        buffer: list[str] = []
+        notices = CouncilNotices(log=log, buffer=buffer)
+
+        notices.decision_hint("r1_only")
+
+        line = buffer[-1]
+        assert "R1 complete" in line
+        # All four keybindings should be surfaced.
+        for key in ("[d]", "[s]", "[c]", "[a]"):
+            assert key in line
+
+    def test_full_hint_mentions_r1_r2_complete(self):
+        log = _StubLog()
+        buffer: list[str] = []
+        notices = CouncilNotices(log=log, buffer=buffer)
+
+        notices.decision_hint("full")
+
+        line = buffer[-1]
+        assert "R1+R2 complete" in line
+        assert "compare drafts" in line

--- a/tests/unit/test_tui_report_writer.py
+++ b/tests/unit/test_tui_report_writer.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from council.app.tui.notices import CouncilNotices
+from council.app.tui.report_writer import DebateReportWriter
+from council.domain.models import (
+    CouncilPack,
+    Debate,
+    ElderAnswer,
+    Round,
+    Turn,
+)
+
+
+class _StubLog:
+    def __init__(self) -> None:
+        self.written: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.written.append(line)
+
+
+def _notices():
+    buf: list[str] = []
+    return CouncilNotices(log=_StubLog(), buffer=buf), buf
+
+
+def _debate():
+    return Debate(
+        id="debate-42",
+        prompt="q",
+        pack=CouncilPack(name="bare", shared_context=None, personas={}),
+        rounds=[
+            Round(
+                number=1,
+                turns=[
+                    Turn(
+                        elder="ada",
+                        answer=ElderAnswer(
+                            elder="ada",
+                            text="hi",
+                            error=None,
+                            agreed=None,
+                            created_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+                        ),
+                    )
+                ],
+            )
+        ],
+        status="in_progress",
+        synthesis=None,
+    )
+
+
+def _view_with_append_report():
+    """Build a view whose synthesis pane captures append_report calls."""
+    view = MagicMock()
+    pane = MagicMock()
+    view.pane.return_value = pane
+    return view, pane
+
+
+class TestDebateReportWriter:
+    async def test_success_path_renders_and_saves(self):
+        service = MagicMock()
+        service.generate_report = AsyncMock(return_value="# report")
+        view, pane = _view_with_append_report()
+        store = MagicMock()
+        store.save.return_value = Path("/tmp/rep.md")
+        notices, buf = _notices()
+        writer = DebateReportWriter(service=service, view=view, report_store=store)
+
+        await writer.write(debate=_debate(), by="ada", notices=notices)
+
+        service.generate_report.assert_awaited_once()
+        view.pane.assert_called_with("synthesis")
+        pane.append_report.assert_called_once_with("# report")
+        store.save.assert_called_once_with(debate_id="debate-42", markdown="# report")
+        assert any("Debate report saved to /tmp/rep.md" in line for line in buf)
+
+    async def test_no_store_renders_but_does_not_save(self):
+        service = MagicMock()
+        service.generate_report = AsyncMock(return_value="# report")
+        view, pane = _view_with_append_report()
+        notices, buf = _notices()
+        writer = DebateReportWriter(service=service, view=view, report_store=None)
+
+        await writer.write(debate=_debate(), by="ada", notices=notices)
+
+        pane.append_report.assert_called_once_with("# report")
+        assert buf == []  # No saved-path notice when there is no store.
+
+    async def test_generate_failure_writes_yellow_notice_and_skips_render(self):
+        service = MagicMock()
+        service.generate_report = AsyncMock(side_effect=RuntimeError("judge offline"))
+        view, pane = _view_with_append_report()
+        notices, buf = _notices()
+        writer = DebateReportWriter(service=service, view=view, report_store=MagicMock())
+
+        await writer.write(debate=_debate(), by="ada", notices=notices)
+
+        pane.append_report.assert_not_called()
+        assert any("Report generation failed: judge offline" in line for line in buf)
+
+    async def test_save_failure_writes_yellow_notice_after_rendering(self):
+        service = MagicMock()
+        service.generate_report = AsyncMock(return_value="# report")
+        view, pane = _view_with_append_report()
+        store = MagicMock()
+        store.save.side_effect = OSError("disk full")
+        notices, buf = _notices()
+        writer = DebateReportWriter(service=service, view=view, report_store=store)
+
+        await writer.write(debate=_debate(), by="ada", notices=notices)
+
+        # Render happens before save — assert that.
+        pane.append_report.assert_called_once_with("# report")
+        assert any("Report file write failed: disk full" in line for line in buf)


### PR DESCRIPTION
## Summary

Unit test coverage for the pure modules and collaborators extracted in the two recent refactors (PR #15 and PR #16). 67 new tests, no behavior changes.

- **`test_headless_printing.py`** (23) — stdout format guards for every print helper. Includes a regression guard for the PR #15 backslash-n bug, mutation-verified to fail if the literal escape returns.
- **`test_headless_rounds.py`** (12) — policy priority, round-execution branching for every policy mode, max-rounds warning, best-R1 selection branches.
- **`test_headless_reporting.py`** (18) — risk-note diversity matrix, synthesis parsing, preference dispatch (multi vs single vs none), report save/no-store/failure paths, sidecar provenance capture.
- **`test_tui_notices.py`/`_health_check.py`/`_cost_notifier.py`/`_report_writer.py`** (14) — the four TUI collaborators each get behavioral coverage (log+buffer writes, healthy/unhealthy branching, cost-delta accumulation across calls, render-vs-save failure handling).

## Test plan

- [x] 588/588 tests pass (previously 521)
- [x] `ruff check` + `ruff format --check` clean
- [x] Mutation verified: reintroducing `\\n` in `printing.py` causes `test_emits_real_newlines_not_literal_backslash_n` to fail, confirming the regression guard is real

🤖 Generated with [Claude Code](https://claude.com/claude-code)